### PR TITLE
fix: Pin @modelcontextprotocol/sdk to a stable version to fix JSON output error

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Junki",
   "license": "ISC",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.17.5",
+    "@modelcontextprotocol/sdk": "1.17.5",
     "socks": "^2.8.6",
     "ssh2": "^1.16.0",
     "zod": "^3.24.2"


### PR DESCRIPTION
This PR fixes a critical bug that causes the server to output invalid JSON, leading to a `SyntaxError` on the client side.

**The Problem:**

The `package.json` file uses a caret `^` for the `@modelcontextprotocol/sdk` dependency (`^1.17.5`). This allows `npm` or `npx` to automatically install a newer minor version. A recent version of the SDK appears to have a bug that produces malformed JSON when multiple responses are sent in quick succession.

**The Fix:**

This PR pins the `@modelcontextprotocol/sdk` dependency to the exact stable version `1.17.5` by removing the `^`. This ensures that a known-good version of the SDK is always used, preventing the JSON parsing error.

This will resolve issues for users of tools like `gemini-cli` who are experiencing `SyntaxError: Expected ',' or ']' after array element in JSON` when interacting with this MCP server.