### PR TITLE
Fix JSON parsing error by redirecting logger output to stderr

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -6,23 +6,14 @@ import { LogLevel } from '../models/types.js';
 export class Logger {
   /**
    * Log a message
+   * Note: All logging goes to stderr to avoid interfering with MCP stdio protocol (which uses stdout)
    */
   public static log(message: string, level: LogLevel = "info"): void {
     const timestamp = new Date().toISOString();
     const formattedMessage = `[${timestamp}] [${level.toUpperCase()}] ${message}`;
 
-    switch (level) {
-      case "error":
-        console.error(formattedMessage);
-        break;
-      case "debug":
-        console.debug(formattedMessage);
-        break;
-      case "info":
-      default:
-        console.info(formattedMessage);
-        break;
-    }
+    // Always write to stderr to avoid corrupting MCP protocol messages on stdout
+    process.stderr.write(formattedMessage + '\n');
   }
 
   /**


### PR DESCRIPTION
## Problem
The logger was writing to \console.info\ and \console.error\, which output to stdout/stderr. In MCP stdio mode, stdout is used for JSON-RPC protocol messages, so logger output was corrupting the protocol messages and causing JSON parsing errors:

\\\
Expected ',' or ']' after array element in JSON at position 5 (line 1 column 6)
\\\

## Solution
- Changed \Logger.log()\ to write to \process.stderr\ instead of \console.info\/console.error
- This prevents logger output from corrupting MCP protocol JSON-RPC messages on stdout
- Also removed \chmod\ command from build script for Windows compatibility

## Testing
Tested with multiple SSH connections and confirmed the JSON parsing errors are resolved. The MCP protocol now works correctly without interference from logger output.