### PR TITLE
Fix compilation on Windows by making chmod platform-dependent

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc && chmod 755 build/index.js",
+    "build": "node scripts/build.js",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+import { execSync } from "node:child_process";
+import { chmodSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const rootDir = join(__dirname, "..");
+const buildFile = join(rootDir, "build", "index.js");
+
+// Run TypeScript compiler
+console.log("Building TypeScript...");
+execSync("tsc", { stdio: "inherit", cwd: rootDir });
+
+// Make executable on Unix-like systems (Linux, macOS, etc.)
+if (process.platform !== "win32") {
+  try {
+    chmodSync(buildFile, 0o755);
+    console.log("Made build/index.js executable");
+  } catch (error) {
+    console.warn(
+      "Warning: Could not set executable permissions:",
+      error.message
+    );
+  }
+} else {
+  console.log("Skipping chmod on Windows");
+}
+
+console.log("Build complete!");


### PR DESCRIPTION
## Problem
The build script uses \chmod 755 build/index.js\ which fails on Windows with:
\\\
'chmod' is not recognized as an internal or external command
\\\

## Solution
- Created \scripts/build.js\ that conditionally runs \chmod\ only on Unix-like systems (Linux, macOS)
- On Windows, chmod is skipped to avoid command not found errors
- Preserves executable permissions on Linux/macOS while being Windows-compatible
- Updated \package.json\ build script to use the new \uild.js\ script

## Testing
- ✅ Builds successfully on Windows (chmod is skipped)
- ✅ Builds successfully on Unix-like systems (chmod sets executable permissions)

This ensures the project can be built on all platforms without errors.