### PR TITLE
[codex] fix MCP shutdown handling

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -10,7 +10,7 @@ import { execSync } from 'child_process';
 console.log('🧪 运行测试...\n');
 
 try {
-  execSync('node --test test/**/*.test.js', {
+  execSync('node --test test/*.test.js', {
     stdio: 'inherit',
     cwd: new URL('..', import.meta.url).pathname
   });

--- a/src/core/mcp-server.ts
+++ b/src/core/mcp-server.ts
@@ -12,7 +12,9 @@ import { SERVER_CONFIG } from "../config/server.js";
 export class SshMcpServer {
   private server: McpServer;
   private sshManager: SSHConnectionManager;
+  private transport?: StdioServerTransport;
   private shutdownHandlersRegistered = false;
+  private shutdownPromise?: Promise<void>;
 
   constructor() {
     this.server = new McpServer(SERVER_CONFIG);
@@ -27,19 +29,45 @@ export class SshMcpServer {
     registerAllTools(this.server);
   }
 
+  private async shutdown(reason: string, exitCode?: number): Promise<void> {
+    if (!this.shutdownPromise) {
+      this.shutdownPromise = (async () => {
+        Logger.log(`Received ${reason}, shutting down SSH MCP server...`, "info");
+
+        this.sshManager.disconnect();
+
+        try {
+          await this.server.close();
+        } catch (error) {
+          Logger.log(
+            `Failed to close MCP server cleanly: ${(error as Error).message}`,
+            "error",
+          );
+        }
+      })();
+    }
+
+    await this.shutdownPromise;
+
+    if (exitCode !== undefined) {
+      process.exit(exitCode);
+    }
+  }
+
   private registerShutdownHandlers(): void {
     if (this.shutdownHandlersRegistered) {
       return;
     }
 
-    const handleShutdown = (signal: string) => {
-      Logger.log(`Received ${signal}, disconnecting SSH clients...`, "info");
-      this.sshManager.disconnect();
+    const handleSignal = (signal: NodeJS.Signals) => {
+      void this.shutdown(signal, 0);
     };
 
-    process.once("SIGINT", () => handleShutdown("SIGINT"));
-    process.once("SIGTERM", () => handleShutdown("SIGTERM"));
-    process.once("beforeExit", () => handleShutdown("beforeExit"));
+    process.once("SIGINT", handleSignal);
+    process.once("SIGTERM", handleSignal);
+    process.stdin.once("end", () => void this.shutdown("stdin end", 0));
+    process.stdin.once("close", () => void this.shutdown("stdin close", 0));
+    process.once("beforeExit", () => void this.shutdown("beforeExit"));
 
     this.shutdownHandlersRegistered = true;
   }
@@ -84,8 +112,8 @@ export class SshMcpServer {
     this.registerTools();
 
     // Create transport instance and connect
-    const transport = new StdioServerTransport();
-    await this.server.connect(transport);
+    this.transport = new StdioServerTransport();
+    await this.server.connect(this.transport);
 
     Logger.log("MCP server connection established");
   }

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -1,0 +1,85 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.join(__dirname, '..');
+const entrypoint = path.join(rootDir, 'build', 'index.js');
+
+function waitForOutput(stream, pattern, timeoutMs = 3000) {
+  return new Promise((resolve, reject) => {
+    let output = '';
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for ${pattern}. Output:\n${output}`));
+    }, timeoutMs);
+
+    const onData = (chunk) => {
+      output += chunk.toString();
+      if (pattern.test(output)) {
+        cleanup();
+        resolve(output);
+      }
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      stream.off('data', onData);
+    };
+
+    stream.on('data', onData);
+  });
+}
+
+function waitForExit(child, timeoutMs = 3000) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error('Process did not exit before timeout'));
+    }, timeoutMs);
+
+    child.once('exit', (code, signal) => {
+      clearTimeout(timeout);
+      resolve({ code, signal });
+    });
+  });
+}
+
+describe('MCP server lifecycle', () => {
+  it('exits after SIGTERM even when stdin remains open', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ssh-mcp-lifecycle-'));
+    const configPath = path.join(tmpDir, 'config.json');
+
+    fs.writeFileSync(configPath, JSON.stringify({
+      test: {
+        host: '127.0.0.1',
+        port: 22,
+        username: 'test',
+        password: 'test',
+        commandWhitelist: ['^echo'],
+      },
+    }));
+
+    const child = spawn(process.execPath, [entrypoint, '--config-file', configPath], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    try {
+      await waitForOutput(child.stderr, /MCP server connection established/);
+
+      child.kill('SIGTERM');
+      const result = await waitForExit(child);
+
+      assert.strictEqual(result.signal, null);
+      assert.strictEqual(result.code, 0);
+    } finally {
+      child.kill('SIGKILL');
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- make SSH MCP server shutdown idempotent and close the MCP server on SIGINT/SIGTERM
- exit with code 0 after graceful signal shutdown so old stdio processes do not remain alive
- handle stdin end/close as shutdown triggers
- add a lifecycle regression test for SIGTERM while stdin remains open
- adjust the test runner glob so local npm test discovers the test files

## Root Cause

The previous SIGINT/SIGTERM handlers only disconnected SSH clients. In Node.js, registering a SIGTERM listener replaces the default terminate behavior, so the process could keep running if the host still held stdio open.

## Validation

- npm run build
- npm test
