### PR TITLE
Add npm package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "description": "SSH-based MCP Server (基于 SSH 的 MCP 服务器)",
   "main": "build/index.js",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/classfang/ssh-mcp-server.git"
+  },
+  "bugs": {
+    "url": "https://github.com/classfang/ssh-mcp-server/issues"
+  },
+  "homepage": "https://github.com/classfang/ssh-mcp-server#readme",
   "bin": {
     "ssh-mcp-server": "build/index.js"
   },


### PR DESCRIPTION
## Summary
- Add npm `repository` metadata pointing to this public GitHub repository.
- Add npm `bugs.url` metadata pointing to the public issue tracker.
- Add npm `homepage` metadata pointing to the README.

## Why
The published package currently does not expose source or issue metadata through npm:

```shell
npm view @fangjunjie/ssh-mcp-server name version repository bugs homepage --json
```

Observed for 1.8.3:

```json
{
  "name": "@fangjunjie/ssh-mcp-server",
  "version": "1.8.3"
}
```

Adding these fields makes it easier for npm users and automated tooling to find the source and report issues.

## Validation
- package metadata parsed successfully with Node.js
- `git diff --check -- package.json`
