### PR TITLE
Handle top-level CLI info flags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,41 @@
 #!/usr/bin/env node
 
 import { SshMcpServer } from "./core/mcp-server.js";
+import { SERVER_CONFIG } from "./config/server.js";
 import { Logger } from "./utils/logger.js";
+
+const HELP_TEXT = `Usage: ssh-mcp-server [options]
+
+Options:
+  --config-file <path>       Load SSH server configs from a JSON file
+  --ssh <config>             Add an SSH config as JSON or legacy key=value pairs
+  --host <host>              Connect to a single SSH host
+  --port <port>              SSH port for single-host mode
+  --username <name>          SSH username for single-host mode
+  --password <password>      SSH password for single-host mode
+  --privateKey <path>        SSH private key path for single-host mode
+  --ssh-config-file <path>   Read host aliases from a custom SSH config file
+  --version, -v              Print package version
+  --help                     Print this help message`;
+
+function hasArg(...names: string[]): boolean {
+  return process.argv.slice(2).some((arg) => names.includes(arg));
+}
 
 /**
  * Main program entry
  */
 async function main(): Promise<void> {
+  if (hasArg("--help")) {
+    console.log(HELP_TEXT);
+    return;
+  }
+
+  if (hasArg("--version", "-v")) {
+    console.log(SERVER_CONFIG.version);
+    return;
+  }
+
   const sshMcpServer = new SshMcpServer();
   await sshMcpServer.run();
 }

--- a/test/cli-info-flags.test.js
+++ b/test/cli-info-flags.test.js
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+const entrypoint = path.join(rootDir, 'build', 'index.js');
+
+function runCli(args) {
+  return spawnSync(process.execPath, [entrypoint, ...args], {
+    cwd: rootDir,
+    encoding: 'utf8',
+  });
+}
+
+describe('CLI info flags', () => {
+  it('prints package version and exits successfully for --version', () => {
+    const result = runCli(['--version']);
+
+    assert.strictEqual(result.status, 0);
+    assert.strictEqual(result.stdout.trim(), '1.8.3');
+    assert.doesNotMatch(result.stderr, /Unknown option/);
+  });
+
+  it('prints help and exits successfully for --help', () => {
+    const result = runCli(['--help']);
+
+    assert.strictEqual(result.status, 0);
+    assert.match(result.stdout, /Usage: ssh-mcp-server/);
+    assert.match(result.stdout, /--config-file/);
+    assert.match(result.stdout, /--ssh/);
+    assert.match(result.stdout, /--version/);
+    assert.doesNotMatch(result.stderr, /Unknown option/);
+  });
+});


### PR DESCRIPTION
## Summary
- Handle `--help` before normal MCP startup so users can inspect CLI usage without triggering config parsing.
- Handle `--version` and `-v` at the entry point using the package server config version.
- Add process-level tests for both info flags.

## Validation
- `npm test`
- `npm run build`
- `node build/index.js --help`
- `node build/index.js --version`
- `node build/index.js -v`
- `npm pack --dry-run --ignore-scripts`
- `git diff --check`