### PR TITLE
feat: support algorithms field in JSON config for custom SSH algorithms

### DIFF
--- a/src/cli/command-line-parser.ts
+++ b/src/cli/command-line-parser.ts
@@ -320,6 +320,7 @@ export class CommandLineParser {
         : undefined,
       passphrase: config.passphrase || process.env.SSH_MCP_PASSPHRASE,
       agent: config.agent,
+      algorithms: config.algorithms,
       socksProxy: config.socksProxy,
       pty: this.parseBoolean(config.pty),
       tryKeyboard: this.parseBoolean(config.tryKeyboard),

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -14,6 +14,7 @@ export interface SSHConfig {
   commandWhitelist?: string[]; // Command whitelist (array of regex strings)
   commandBlacklist?: string[]; // Command blacklist (array of regex strings)
   socksProxy?: string; // SOCKS proxy URL, e.g. 'socks://user:pass@host:port'
+  algorithms?: Record<string, string[]>; // Custom SSH algorithms (kex, cipher, serverHostKey, hmac, compress)
   pty?: boolean; // Allocate pseudo-tty for command execution, default: true
   allowedLocalPaths?: string[]; // Allowed local paths for upload/download
   allowedRemotePaths?: string[]; // Allowed remote paths for SFTP upload/download (POSIX, absolute)

--- a/src/services/ssh-connection-manager.ts
+++ b/src/services/ssh-connection-manager.ts
@@ -814,6 +814,9 @@ export class SSHConnectionManager {
       keepaliveCountMax:
         config.keepaliveCountMax || DEFAULT_KEEPALIVE_COUNT_MAX,
     };
+    if (config.algorithms) {
+      sshConfig.algorithms = config.algorithms;
+    }
 
     if (config.socksProxy) {
       try {


### PR DESCRIPTION
Closes #65

## Changes

- **types.ts**: Add `algorithms` to `SSHConfig` interface
- **command-line-parser.ts**: Preserve `algorithms` in `normalizeConfig()`
- **ssh-connection-manager.ts**: Pass `algorithms` to ssh2's `client.connect()`

## Why

Old SSH servers using deprecated algorithms (ssh-rsa, ssh-dss host keys, hmac-sha1/hmac-md5 MACs) fail to connect with ssh2's default algorithm negotiation. This allows users to specify custom algorithms in `ssh-targets.json`:

```json
{
  "name": "legacy-server",
  "host": "192.168.1.100",
  "port": 22,
  "username": "admin",
  "algorithms": {
    "serverHostKey": ["ssh-rsa", "ssh-dss"],
    "hmac": ["hmac-sha1", "hmac-md5"]
  }
}
```

Backward compatible — when `algorithms` is not specified, behavior is unchanged.