### PR TITLE
feat: support custom SSH algorithms in JSON config

### DIFF
--- a/src/cli/command-line-parser.ts
+++ b/src/cli/command-line-parser.ts
@@ -320,6 +320,7 @@ export class CommandLineParser {
         : undefined,
       passphrase: config.passphrase || process.env.SSH_MCP_PASSPHRASE,
       agent: config.agent,
+      algorithms: config.algorithms,
       socksProxy: config.socksProxy,
       pty: this.parseBoolean(config.pty),
       tryKeyboard: this.parseBoolean(config.tryKeyboard),

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -14,6 +14,7 @@ export interface SSHConfig {
   commandWhitelist?: string[]; // Command whitelist (array of regex strings)
   commandBlacklist?: string[]; // Command blacklist (array of regex strings)
   socksProxy?: string; // SOCKS proxy URL, e.g. 'socks://user:pass@host:port'
+  algorithms?: Record<string, string[]>; // Custom SSH algorithms (kex, cipher, serverHostKey, hmac, compress)
   pty?: boolean; // Allocate pseudo-tty for command execution, default: true
   allowedLocalPaths?: string[]; // Allowed local paths for upload/download
   allowedRemotePaths?: string[]; // Allowed remote paths for SFTP upload/download (POSIX, absolute)

--- a/src/services/ssh-connection-manager.ts
+++ b/src/services/ssh-connection-manager.ts
@@ -814,6 +814,9 @@ export class SSHConnectionManager {
       keepaliveCountMax:
         config.keepaliveCountMax || DEFAULT_KEEPALIVE_COUNT_MAX,
     };
+    if (config.algorithms) {
+      sshConfig.algorithms = config.algorithms;
+    }
 
     if (config.socksProxy) {
       try {


### PR DESCRIPTION
## Summary

- Preserve the optional algorithms field when parsing JSON SSH configs.
- Forward custom algorithms to the ssh2 client connection options.
- Enables compatibility configuration for legacy SSH servers.

Equivalent functional change to #66, submitted from the renhedata fork.

## Testing

- npm test