### PR TITLE
perf: lazy-load SSH dependencies

### DIFF
--- a/src/services/ssh-connection-manager.ts
+++ b/src/services/ssh-connection-manager.ts
@@ -1,5 +1,5 @@
-import { Client, ClientChannel, SFTPWrapper } from "ssh2";
-import { SocksClient } from "socks";
+import { createRequire } from "node:module";
+import type { Client, ClientChannel, SFTPWrapper } from "ssh2";
 import {
   SSHConfig,
   SshConnectionConfigMap,
@@ -11,6 +11,8 @@ import { ToolError } from "../utils/tool-error.js";
 import fs from "fs";
 import path from "path";
 import { pipeline } from "node:stream/promises";
+
+const require = createRequire(import.meta.url);
 
 type RunCommandOptions = {
   timeout?: number;
@@ -747,6 +749,7 @@ export class SSHConnectionManager {
   }
 
   private createClient(): Client {
+    const { Client } = require("ssh2") as typeof import("ssh2");
     return new Client();
   }
 
@@ -820,6 +823,7 @@ export class SSHConnectionManager {
 
     if (config.socksProxy) {
       try {
+        const { SocksClient } = require("socks") as typeof import("socks");
         const proxyUrl = new URL(config.socksProxy);
         const proxyHost = proxyUrl.hostname;
         const proxyPort = Number.parseInt(proxyUrl.port, 10);

--- a/test/lazy-dependencies.test.js
+++ b/test/lazy-dependencies.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+import * as path from 'node:path';
+
+test('does not load SSH dependencies when importing the connection manager', () => {
+  const managerUrl = pathToFileURL(
+    path.resolve('build/services/ssh-connection-manager.js'),
+  ).href;
+  const loader = `data:text/javascript,${encodeURIComponent(`
+    export async function resolve(specifier, context, nextResolve) {
+      if (specifier === 'ssh2' || specifier === 'socks') {
+        throw new Error('eager SSH dependency: ' + specifier);
+      }
+      return nextResolve(specifier, context);
+    }
+  `)}`;
+  const result = spawnSync(
+    process.execPath,
+    [
+      '--experimental-loader',
+      loader,
+      '--input-type=module',
+      '--eval',
+      `await import(${JSON.stringify(managerUrl)});`,
+    ],
+    { cwd: path.resolve('.'), encoding: 'utf8', timeout: 10_000 },
+  );
+
+  assert.strictEqual(
+    result.status,
+    0,
+    [result.error?.stack, result.stderr, result.stdout].filter(Boolean).join('\n'),
+  );
+});


### PR DESCRIPTION
## Summary

- load `ssh2` only when an SSH client is first created
- load `socks` only when a connection uses `socksProxy`
- keep the existing synchronous interfaces and all public behavior unchanged
- add a regression test that rejects eager resolution of either dependency

## Why

Each stdio MCP client starts its own server process. Previously, idle processes loaded both SSH dependencies before any SSH tool was called. Deferring them lowers the baseline memory cost for clients that list tools but do not establish a connection.

## Benchmark

Measured on Windows with Node `v24.14.0`, using the same config for both variants. Each result is the median of three interleaved runs after one warm-up and 10 seconds idle.

| Metric | v1.8.5 | This branch | Change |
| --- | ---: | ---: | ---: |
| Private memory | 56.0 MiB | 34.7 MiB | -21.3 MiB (-38.1%) |
| RSS | 76.7 MiB | 70.1 MiB | -6.6 MiB |
| MCP handshake | 226 ms | 165 ms | -61 ms |

After first use, private memory returned to `55.8 MiB` for a direct connection path and `56.0 MiB` for a proxy path, confirming that the dependency cost is deferred rather than hidden.

## Verification

- `npm run build`
- `node --test test/lazy-dependencies.test.js`
- existing SOCKS proxy test
- full Windows suite: `113/119` pass versus `112/118` on pristine `main`; the same six existing Windows path, symlink, and signal tests fail in both runs

## Release request

If this is merged, would you please publish a new npm version so downstream MCP configurations can consume the optimization without installing directly from GitHub? Thank you.
