### PR TITLE
fix: keep stderr on success and cap captured command output

### DIFF
--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -26,6 +26,7 @@ export interface SSHConfig {
   shellCommandTimeoutMs?: number; // Shell command timeout override, default: 30000ms
   connectionTimeoutMs?: number; // SSH connection and handshake timeout, default: 30000ms
   sftpTimeoutMs?: number; // SFTP open and transfer timeout, default: 300000ms
+  maxOutputBytes?: number; // Max captured bytes per command (stdout+stderr) before aborting, default: 10485760; set 0 to disable
   keepaliveIntervalMs?: number; // SSH keepalive interval, default: 10000ms
   keepaliveCountMax?: number; // Unanswered keepalive packets before disconnect, default: 3
   commandTemplate?: string; // Command template, use <quotedCommand> for shell arguments or <command> for raw insertion

--- a/src/services/ssh-connection-manager.ts
+++ b/src/services/ssh-connection-manager.ts
@@ -44,6 +44,7 @@ const DEFAULT_CONNECTION_TIMEOUT_MS = 30000;
 const DEFAULT_KEEPALIVE_INTERVAL_MS = 10000;
 const DEFAULT_KEEPALIVE_COUNT_MAX = 3;
 const DEFAULT_SFTP_TIMEOUT_MS = 300000;
+const DEFAULT_MAX_OUTPUT_BYTES = 10 * 1024 * 1024;
 
 function applyCommandTemplate(template: string, command: string): string {
   const quotedCommand = shellQuote(command);
@@ -827,6 +828,15 @@ export class SSHConnectionManager {
     return config.sftpTimeoutMs || DEFAULT_SFTP_TIMEOUT_MS;
   }
 
+  private getMaxOutputBytes(config: SSHConfig): number {
+    const configured = config.maxOutputBytes;
+    if (configured === undefined) {
+      return DEFAULT_MAX_OUTPUT_BYTES;
+    }
+    // Any non-positive value disables the cap.
+    return configured > 0 ? configured : 0;
+  }
+
   private async createSocksProxySocket(
     proxyUrl: URL,
     config: SSHConfig,
@@ -1298,6 +1308,23 @@ export class SSHConnectionManager {
     return outputSections.join("\n");
   }
 
+  /**
+   * Format the output of a command that finished successfully.
+   *
+   * stderr is kept instead of being dropped: with `pty: false` a successful
+   * command's stderr is delivered on a separate channel, and discarding it
+   * silently loses warnings and progress output written there by tools such as
+   * git, docker and npm. With the default `pty: true` the remote end merges
+   * stderr into stdout, so `stderr` is empty here and the output is unchanged.
+   */
+  private formatCommandSuccess(stdout: string, stderr: string): string {
+    if (!stderr) {
+      return stdout;
+    }
+
+    return [stdout, `[stderr]\n${stderr}`].filter(Boolean).join("\n");
+  }
+
   private async runCommandInternal(
     cmdString: string,
     directory?: string,
@@ -1408,12 +1435,51 @@ export class SSHConnectionManager {
           let errorData = "";
           let exitCode: number | undefined;
           let exitSignal: string | undefined;
+          const maxOutputBytes = this.getMaxOutputBytes(config);
+          let capturedBytes = 0;
+          let truncated = false;
 
-          stream.on("data", (chunk: Buffer) => (data += chunk.toString()));
-          stream.stderr.on(
-            "data",
-            (chunk: Buffer) => (errorData += chunk.toString()),
-          );
+          // Without a cap a single command (`cat` on a huge file, an unbounded
+          // `journalctl`, ...) can buffer unbounded output in memory until the
+          // command timeout fires. Stop capturing and close the channel instead.
+          const appendChunk = (chunk: Buffer, isStderr: boolean) => {
+            if (truncated) {
+              return;
+            }
+
+            if (
+              maxOutputBytes > 0 &&
+              capturedBytes + chunk.length > maxOutputBytes
+            ) {
+              const remaining = maxOutputBytes - capturedBytes;
+              if (remaining > 0) {
+                const partial = chunk.subarray(0, remaining).toString();
+                if (isStderr) {
+                  errorData += partial;
+                } else {
+                  data += partial;
+                }
+              }
+              capturedBytes = maxOutputBytes;
+              truncated = true;
+              try {
+                stream.close();
+              } catch {
+                // Ignore close errors while aborting an oversized command.
+              }
+              return;
+            }
+
+            capturedBytes += chunk.length;
+            if (isStderr) {
+              errorData += chunk.toString();
+            } else {
+              data += chunk.toString();
+            }
+          };
+
+          stream.on("data", (chunk: Buffer) => appendChunk(chunk, false));
+          stream.stderr.on("data", (chunk: Buffer) => appendChunk(chunk, true));
 
           stream.on(
             "exit",
@@ -1440,6 +1506,21 @@ export class SSHConnectionManager {
 
             const stdout = data.trimEnd();
             const stderr = errorData.trimEnd();
+
+            // We closed the channel ourselves, so the resulting exit status is
+            // our own doing — report the truncation rather than a bogus failure.
+            if (truncated) {
+              resolve(
+                [
+                  this.formatCommandSuccess(stdout, stderr),
+                  `[truncated] Output exceeded maxOutputBytes=${maxOutputBytes}; the command was aborted.`,
+                ]
+                  .filter(Boolean)
+                  .join("\n"),
+              );
+              return;
+            }
+
             const hasNonZeroExitCode =
               exitCode !== undefined && exitCode !== 0;
             const hasExitSignal =
@@ -1466,7 +1547,7 @@ export class SSHConnectionManager {
               return;
             }
 
-            resolve(stdout);
+            resolve(this.formatCommandSuccess(stdout, stderr));
           });
 
           stream.on("error", (streamError: Error) => {

--- a/test/ssh-connection-manager.test.js
+++ b/test/ssh-connection-manager.test.js
@@ -1198,6 +1198,124 @@ describe('SSH Connection Manager', () => {
       assert.strictEqual(client.execCalls.length, 1);
     });
 
+    it('命令成功时保留 stderr 而不是丢弃', async () => {
+      const stream = new FakeExecStream();
+      const client = new FakeClient({
+        onConnect: () => setImmediate(() => client.emit('ready')),
+        onExec: ({ callback }) => {
+          callback(undefined, stream);
+          setImmediate(() => {
+            stream.emit('data', Buffer.from('out-line\n'));
+            stream.stderr.emit('data', Buffer.from('warn-line\n'));
+            stream.emit('exit', 0);
+            stream.emit('close', 0);
+          });
+        },
+      });
+
+      manager.createClient = () => client;
+      manager.scheduleStatusCollection = () => {};
+      manager.setConfig({
+        exec: createPasswordConfig({
+          name: 'exec',
+          transportMode: 'exec',
+          pty: false,
+        }),
+      });
+
+      const result = await manager.executeCommand('cmd', undefined, 'exec');
+      assert.strictEqual(result, 'out-line\n[stderr]\nwarn-line');
+    });
+
+    it('命令成功且无 stderr 时输出保持原样', async () => {
+      const stream = new FakeExecStream();
+      const client = new FakeClient({
+        onConnect: () => setImmediate(() => client.emit('ready')),
+        onExec: ({ callback }) => {
+          callback(undefined, stream);
+          setImmediate(() => {
+            stream.emit('data', Buffer.from('only-stdout\n'));
+            stream.emit('exit', 0);
+            stream.emit('close', 0);
+          });
+        },
+      });
+
+      manager.createClient = () => client;
+      manager.scheduleStatusCollection = () => {};
+      manager.setConfig({
+        exec: createPasswordConfig({ name: 'exec', transportMode: 'exec' }),
+      });
+
+      const result = await manager.executeCommand('cmd', undefined, 'exec');
+      assert.strictEqual(result, 'only-stdout');
+    });
+
+    it('输出超过 maxOutputBytes 时截断并中止命令', async () => {
+      const stream = new FakeExecStream();
+      let closeCalls = 0;
+      stream.close = function close() {
+        closeCalls += 1;
+        this.emit('close');
+      };
+
+      const client = new FakeClient({
+        onConnect: () => setImmediate(() => client.emit('ready')),
+        onExec: ({ callback }) => {
+          callback(undefined, stream);
+          setImmediate(() => {
+            stream.emit('data', Buffer.from('abcdefghij'));
+          });
+        },
+      });
+
+      manager.createClient = () => client;
+      manager.scheduleStatusCollection = () => {};
+      manager.setConfig({
+        exec: createPasswordConfig({
+          name: 'exec',
+          transportMode: 'exec',
+          maxOutputBytes: 8,
+        }),
+      });
+
+      const result = await manager.executeCommand('cmd', undefined, 'exec');
+      assert.strictEqual(
+        result,
+        'abcdefgh\n[truncated] Output exceeded maxOutputBytes=8; the command was aborted.',
+      );
+      assert.strictEqual(closeCalls, 1);
+    });
+
+    it('maxOutputBytes 为 0 时不限制输出', async () => {
+      const stream = new FakeExecStream();
+      const payload = 'x'.repeat(4096);
+      const client = new FakeClient({
+        onConnect: () => setImmediate(() => client.emit('ready')),
+        onExec: ({ callback }) => {
+          callback(undefined, stream);
+          setImmediate(() => {
+            stream.emit('data', Buffer.from(payload));
+            stream.emit('exit', 0);
+            stream.emit('close', 0);
+          });
+        },
+      });
+
+      manager.createClient = () => client;
+      manager.scheduleStatusCollection = () => {};
+      manager.setConfig({
+        exec: createPasswordConfig({
+          name: 'exec',
+          transportMode: 'exec',
+          maxOutputBytes: 0,
+        }),
+      });
+
+      const result = await manager.executeCommand('cmd', undefined, 'exec');
+      assert.strictEqual(result, payload);
+    });
+
     it('exec channel 打不开时会按命令超时失效连接', async () => {
       const client = new FakeClient({
         onConnect: () => setImmediate(() => client.emit('ready')),


### PR DESCRIPTION
## Problem

Two independent issues in the exec transport, both in `runExecCommand`.

### 1. stderr is dropped when a command succeeds

`stderr` is only formatted on the failure path (`formatCommandFailure`). The success path does `resolve(stdout)` and throws the captured stderr away.

Under the default `pty: true` this is masked — the remote merges stderr into the stdout channel, so it shows up anyway. Under `pty: false` it is silently lost, which matters for tools that write warnings and progress to stderr (git, docker, npm).

### 2. Captured output is unbounded

`data += chunk.toString()` has no cap. A single command — `cat` on a large file, an unbounded `journalctl`, `yes | base64` — buffers everything in memory until the command timeout fires. On a fast link that is gigabytes.

## Changes

- `formatCommandSuccess()` appends a `[stderr]` section when stderr is non-empty, reusing the format `formatCommandFailure` already uses.
- New `maxOutputBytes` config (default 10 MiB, `0` disables it). When the cap is hit, capture stops, the channel is closed, and a `[truncated]` notice is appended.

Truncation `resolve`s rather than `reject`s: the non-zero exit status that follows is caused by our own `close()`, so reporting it as a command failure would be misleading.

## Compatibility

Unchanged under the default `pty: true` — stderr arrives merged on the stdout channel, so the new stderr section stays empty.

Verified against a live server: stock 1.8.7 and this branch return byte-identical output for `sh -c 'echo OUT; echo ERR >&2; exit 0'`.

## Tests

4 new cases in `test/ssh-connection-manager.test.js`:

- stderr preserved on success (`pty: false`)
- output unchanged when there is no stderr
- output truncated and channel closed once `maxOutputBytes` is exceeded
- no cap applied when `maxOutputBytes: 0`

Full suite: **130 passing** (126 before this change).

## Not included

The shell transport has the same unbounded-buffer problem in `appendShellBuffer`, but that buffer is shared across commands and truncating it would break the `__MCP_END__` marker protocol — it needs a different strategy (most likely dropping the connection). Happy to follow up separately if you would like it handled too.