### PR TITLE
perf: use SFTP fastGet/fastPut for large transfers

### DIFF
--- a/src/services/ssh-connection-manager.ts
+++ b/src/services/ssh-connection-manager.ts
@@ -1,5 +1,5 @@
 import { createRequire } from "node:module";
-import type { Client, ClientChannel, SFTPWrapper } from "ssh2";
+import type { Client, ClientChannel, SFTPWrapper, Stats } from "ssh2";
 import {
   SSHConfig,
   SshConnectionConfigMap,
@@ -45,6 +45,24 @@ const DEFAULT_KEEPALIVE_INTERVAL_MS = 10000;
 const DEFAULT_KEEPALIVE_COUNT_MAX = 3;
 const DEFAULT_SFTP_TIMEOUT_MS = 300000;
 const DEFAULT_MAX_OUTPUT_BYTES = 10 * 1024 * 1024;
+
+// ssh2's SFTP ReadStream/WriteStream keep a single request in flight, so
+// transfer throughput is capped at one chunk per round trip regardless of the
+// available bandwidth. fastGet/fastPut pipeline `concurrency` chunks instead,
+// which is what makes large transfers usable on high latency links.
+const SFTP_FAST_TRANSFER_OPTIONS = {
+  concurrency: 64,
+  chunkSize: 32 * 1024,
+} as const;
+
+// Under this size the streaming path already completes in a couple of round
+// trips, so the extra stat fastGet needs would cost more than the concurrency
+// saves. Staying on the streaming path below the threshold also keeps the
+// existing behaviour for files whose reported size is unusable: fastGet/fastPut
+// plan their chunks from that size and treat `size <= 0` as "nothing to
+// transfer", which would silently produce an empty file for pseudo files such
+// as /proc/cpuinfo.
+const SFTP_FAST_TRANSFER_MIN_BYTES = 256 * 1024;
 
 function applyCommandTemplate(template: string, command: string): string {
   const quotedCommand = shellQuote(command);
@@ -543,15 +561,43 @@ export class SSHConnectionManager {
     );
 
     try {
-      await this.withTimeout(
-        pipeline(
-          fs.createReadStream(validatedLocalPath),
-          sftp.createWriteStream(validatedRemotePath),
-        ),
-        sftpTimeoutMs,
-        () => this.invalidateConnection(key),
-        `SFTP upload timed out after ${sftpTimeoutMs}ms`,
+      const localSize = await this.getLocalSizeForFastTransfer(
+        validatedLocalPath,
       );
+
+      if (localSize === undefined) {
+        await this.withTimeout(
+          pipeline(
+            fs.createReadStream(validatedLocalPath),
+            sftp.createWriteStream(validatedRemotePath),
+          ),
+          sftpTimeoutMs,
+          () => this.invalidateConnection(key),
+          `SFTP upload timed out after ${sftpTimeoutMs}ms`,
+        );
+      } else {
+        await this.withTimeout(
+          new Promise<void>((resolve, reject) => {
+            sftp.fastPut(
+              validatedLocalPath,
+              validatedRemotePath,
+              SFTP_FAST_TRANSFER_OPTIONS,
+              (err) => (err ? reject(err) : resolve()),
+            );
+          }),
+          sftpTimeoutMs,
+          () => this.invalidateConnection(key),
+          `SFTP upload timed out after ${sftpTimeoutMs}ms`,
+        );
+        await this.appendUploadTail(
+          sftp,
+          validatedLocalPath,
+          validatedRemotePath,
+          localSize,
+          sftpTimeoutMs,
+          key,
+        );
+      }
       return "File uploaded successfully";
     } catch (error) {
       if (error instanceof ToolError && error.code === "OPERATION_TIMEOUT") {
@@ -607,15 +653,49 @@ export class SSHConnectionManager {
       .slice(2)}`;
 
     try {
-      await this.withTimeout(
-        pipeline(
-          sftp.createReadStream(validatedRemotePath),
-          fs.createWriteStream(tempLocalPath, { flags: "wx" }),
-        ),
+      const remoteSize = await this.getRemoteSizeForFastTransfer(
+        sftp,
+        validatedRemotePath,
         sftpTimeoutMs,
-        () => this.invalidateConnection(key),
-        `SFTP download timed out after ${sftpTimeoutMs}ms`,
+        key,
       );
+
+      if (remoteSize === undefined) {
+        await this.withTimeout(
+          pipeline(
+            sftp.createReadStream(validatedRemotePath),
+            fs.createWriteStream(tempLocalPath, { flags: "wx" }),
+          ),
+          sftpTimeoutMs,
+          () => this.invalidateConnection(key),
+          `SFTP download timed out after ${sftpTimeoutMs}ms`,
+        );
+      } else {
+        // fastGet opens the destination with "w", which would drop the
+        // exclusive-create guarantee the streaming path gets from "wx".
+        // Claiming the temp name first keeps it.
+        await fs.promises.writeFile(tempLocalPath, "", { flag: "wx" });
+        await this.withTimeout(
+          new Promise<void>((resolve, reject) => {
+            sftp.fastGet(
+              validatedRemotePath,
+              tempLocalPath,
+              SFTP_FAST_TRANSFER_OPTIONS,
+              (err) => (err ? reject(err) : resolve()),
+            );
+          }),
+          sftpTimeoutMs,
+          () => this.invalidateConnection(key),
+          `SFTP download timed out after ${sftpTimeoutMs}ms`,
+        );
+        await this.appendDownloadTail(
+          sftp,
+          validatedRemotePath,
+          tempLocalPath,
+          sftpTimeoutMs,
+          key,
+        );
+      }
       await fs.promises.rename(tempLocalPath, validatedLocalPath);
       return "File downloaded successfully";
     } catch (error) {
@@ -660,6 +740,138 @@ export class SSHConnectionManager {
         resolve(sftp);
       });
     });
+  }
+
+  private statRemote(
+    sftp: SFTPWrapper,
+    remotePath: string,
+  ): Promise<Stats> {
+    return new Promise<Stats>((resolve, reject) => {
+      sftp.stat(remotePath, (err, stats) =>
+        err ? reject(err) : resolve(stats),
+      );
+    });
+  }
+
+  /**
+   * Size to hand to the concurrent transfer path, or undefined to stay on the
+   * streaming path. Anything unexpected — a missing file, a directory, a
+   * server without stat support — falls back so the streaming path reports the
+   * same error it reports today.
+   */
+  private async getRemoteSizeForFastTransfer(
+    sftp: SFTPWrapper,
+    remotePath: string,
+    timeoutMs: number,
+    key: string,
+  ): Promise<number | undefined> {
+    let stats: Stats;
+    try {
+      stats = await this.withTimeout(
+        this.statRemote(sftp, remotePath),
+        timeoutMs,
+        () => this.invalidateConnection(key),
+        `SFTP stat timed out after ${timeoutMs}ms`,
+      );
+    } catch (error) {
+      // A timeout already tore the connection down, so it has to surface.
+      if (error instanceof ToolError) {
+        throw error;
+      }
+      return undefined;
+    }
+
+    return stats.isFile() && stats.size >= SFTP_FAST_TRANSFER_MIN_BYTES
+      ? stats.size
+      : undefined;
+  }
+
+  private async getLocalSizeForFastTransfer(
+    localPath: string,
+  ): Promise<number | undefined> {
+    try {
+      const stats = await fs.promises.stat(localPath);
+      return stats.isFile() && stats.size >= SFTP_FAST_TRANSFER_MIN_BYTES
+        ? stats.size
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * fastGet transfers exactly the byte count the remote file had when it
+   * started, so data appended while it ran would be dropped. The streaming path
+   * reads until EOF and would have picked that tail up, so fetch it here to
+   * keep both paths equivalent for files that are still being written.
+   */
+  private async appendDownloadTail(
+    sftp: SFTPWrapper,
+    remotePath: string,
+    tempLocalPath: string,
+    timeoutMs: number,
+    key: string,
+  ): Promise<void> {
+    const downloadedBytes = (await fs.promises.stat(tempLocalPath)).size;
+    const stats = await this.withTimeout(
+      this.statRemote(sftp, remotePath),
+      timeoutMs,
+      () => this.invalidateConnection(key),
+      `SFTP stat timed out after ${timeoutMs}ms`,
+    );
+
+    if (stats.size <= downloadedBytes) {
+      return;
+    }
+
+    await this.withTimeout(
+      pipeline(
+        sftp.createReadStream(remotePath, { start: downloadedBytes }),
+        fs.createWriteStream(tempLocalPath, { flags: "a" }),
+      ),
+      timeoutMs,
+      () => this.invalidateConnection(key),
+      `SFTP download timed out after ${timeoutMs}ms`,
+    );
+  }
+
+  /**
+   * Upload counterpart of appendDownloadTail. The local stat is free, so the
+   * remote round trip only happens when the local file actually grew.
+   */
+  private async appendUploadTail(
+    sftp: SFTPWrapper,
+    localPath: string,
+    remotePath: string,
+    sizeBeforeTransfer: number,
+    timeoutMs: number,
+    key: string,
+  ): Promise<void> {
+    const currentLocalSize = (await fs.promises.stat(localPath)).size;
+    if (currentLocalSize <= sizeBeforeTransfer) {
+      return;
+    }
+
+    const stats = await this.withTimeout(
+      this.statRemote(sftp, remotePath),
+      timeoutMs,
+      () => this.invalidateConnection(key),
+      `SFTP stat timed out after ${timeoutMs}ms`,
+    );
+
+    if (stats.size >= currentLocalSize) {
+      return;
+    }
+
+    await this.withTimeout(
+      pipeline(
+        fs.createReadStream(localPath, { start: stats.size }),
+        sftp.createWriteStream(remotePath, { flags: "a" }),
+      ),
+      timeoutMs,
+      () => this.invalidateConnection(key),
+      `SFTP upload timed out after ${timeoutMs}ms`,
+    );
   }
 
   private closeSftp(sftp: SFTPWrapper): void {

--- a/test/ssh-connection-manager.test.js
+++ b/test/ssh-connection-manager.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import { EventEmitter } from 'node:events';
 import http from 'node:http';
 import https from 'node:https';
-import { Writable } from 'node:stream';
+import { Readable, Writable } from 'node:stream';
 import { setTimeout as delay } from 'node:timers/promises';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -87,6 +87,72 @@ class FakeShellChannel extends EventEmitter {
 class FakeSftp extends EventEmitter {
   end() {
     this.emit('end');
+  }
+}
+
+function fakeStats(size, { isFile = true } = {}) {
+  return { size, isFile: () => isFile, isDirectory: () => !isFile };
+}
+
+/**
+ * SFTP double that records which transfer path the manager picked
+ * (fastGet/fastPut vs the sequential stream) and serves remote content.
+ */
+class FakeTransferSftp extends EventEmitter {
+  constructor(handlers = {}) {
+    super();
+    this.handlers = handlers;
+    this.statCalls = [];
+    this.fastGetCalls = [];
+    this.fastPutCalls = [];
+    this.readStreamCalls = [];
+    this.writeStreamCalls = [];
+    this.uploadedChunks = [];
+  }
+
+  end() {
+    this.emit('end');
+  }
+
+  stat(remotePath, callback) {
+    this.statCalls.push(remotePath);
+    const size = this.handlers.statSizes.length > 1
+      ? this.handlers.statSizes.shift()
+      : this.handlers.statSizes[0];
+    setImmediate(() => callback(undefined, fakeStats(size, this.handlers)));
+  }
+
+  fastGet(remotePath, localPath, options, callback) {
+    this.fastGetCalls.push({ remotePath, localPath, options });
+    const content = this.handlers.remoteContent.subarray(
+      0,
+      this.handlers.fastGetBytes ?? this.handlers.remoteContent.length,
+    );
+    fs.writeFileSync(localPath, content);
+    setImmediate(() => callback());
+  }
+
+  fastPut(localPath, remotePath, options, callback) {
+    this.fastPutCalls.push({ localPath, remotePath, options });
+    setImmediate(() => callback());
+  }
+
+  createReadStream(remotePath, options = {}) {
+    this.readStreamCalls.push({ remotePath, options });
+    return Readable.from([
+      this.handlers.remoteContent.subarray(options.start ?? 0),
+    ]);
+  }
+
+  createWriteStream(remotePath, options = {}) {
+    this.writeStreamCalls.push({ remotePath, options });
+    const chunks = this.uploadedChunks;
+    return new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(Buffer.from(chunk));
+        callback();
+      },
+    });
   }
 }
 
@@ -1617,6 +1683,128 @@ describe('SSH Connection Manager', () => {
 
       const result = await manager.executeCommand('ls', "/tmp/it's", 'quote');
       assert.strictEqual(result, 'done');
+    });
+  });
+
+  describe('SFTP 并发传输', () => {
+    const FAST_MIN_BYTES = 256 * 1024;
+
+    function setupTransfer(sftp) {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ssh-mcp-xfer-'));
+      const client = new FakeClient({
+        onConnect: () => setImmediate(() => client.emit('ready')),
+        onSftp: (callback) => callback(undefined, sftp),
+      });
+
+      manager.createClient = () => client;
+      manager.scheduleStatusCollection = () => {};
+      manager.setConfig({
+        exec: createPasswordConfig({
+          name: 'exec',
+          transportMode: 'exec',
+          allowedLocalPaths: [tempDir],
+        }),
+      });
+
+      return tempDir;
+    }
+
+    it('小文件上传仍走顺序流，不触发 fastPut', async () => {
+      const sftp = new FakeTransferSftp({ statSizes: [0] });
+      const tempDir = setupTransfer(sftp);
+      const localFile = path.join(tempDir, 'small.bin');
+      fs.writeFileSync(localFile, Buffer.alloc(1024, 7));
+
+      await manager.upload(localFile, '/remote/small.bin', 'exec');
+
+      assert.strictEqual(sftp.fastPutCalls.length, 0);
+      assert.strictEqual(sftp.writeStreamCalls.length, 1);
+      assert.strictEqual(
+        Buffer.concat(sftp.uploadedChunks).length,
+        1024,
+      );
+    });
+
+    it('大文件上传使用 fastPut 并发传输', async () => {
+      const sftp = new FakeTransferSftp({ statSizes: [FAST_MIN_BYTES] });
+      const tempDir = setupTransfer(sftp);
+      const localFile = path.join(tempDir, 'big.bin');
+      fs.writeFileSync(localFile, Buffer.alloc(FAST_MIN_BYTES, 7));
+
+      await manager.upload(localFile, '/remote/big.bin', 'exec');
+
+      assert.strictEqual(sftp.fastPutCalls.length, 1);
+      assert.strictEqual(sftp.writeStreamCalls.length, 0);
+      assert.strictEqual(sftp.fastPutCalls[0].options.concurrency, 64);
+      assert.strictEqual(sftp.fastPutCalls[0].options.chunkSize, 32 * 1024);
+    });
+
+    // fastGet plans its chunks from the reported size and treats 0 as "nothing
+    // to transfer" while still reporting success, so /proc-style pseudo files
+    // must never reach it.
+    it('远端 size 为 0 的伪文件走顺序流并拿到真实内容', async () => {
+      const content = Buffer.from('processor\t: 0\nmodel name\t: fake\n');
+      const sftp = new FakeTransferSftp({
+        statSizes: [0],
+        remoteContent: content,
+      });
+      const tempDir = setupTransfer(sftp);
+      const localFile = path.join(tempDir, 'cpuinfo');
+
+      await manager.download('/proc/cpuinfo', localFile, 'exec');
+
+      assert.strictEqual(sftp.fastGetCalls.length, 0);
+      assert.deepStrictEqual(fs.readFileSync(localFile), content);
+    });
+
+    it('远端目录不会走 fastGet', async () => {
+      const sftp = new FakeTransferSftp({
+        statSizes: [FAST_MIN_BYTES],
+        isFile: false,
+        remoteContent: Buffer.alloc(0),
+      });
+      const tempDir = setupTransfer(sftp);
+
+      await manager.download('/remote/dir', path.join(tempDir, 'dir'), 'exec');
+
+      assert.strictEqual(sftp.fastGetCalls.length, 0);
+      assert.strictEqual(sftp.readStreamCalls.length, 1);
+    });
+
+    it('大文件下载使用 fastGet 并发传输', async () => {
+      const content = Buffer.alloc(FAST_MIN_BYTES, 3);
+      const sftp = new FakeTransferSftp({
+        statSizes: [FAST_MIN_BYTES],
+        remoteContent: content,
+      });
+      const tempDir = setupTransfer(sftp);
+      const localFile = path.join(tempDir, 'big.bin');
+
+      await manager.download('/remote/big.bin', localFile, 'exec');
+
+      assert.strictEqual(sftp.fastGetCalls.length, 1);
+      assert.strictEqual(sftp.readStreamCalls.length, 0);
+      assert.deepStrictEqual(fs.readFileSync(localFile), content);
+    });
+
+    it('下载期间远端文件增长时补齐尾部', async () => {
+      const head = Buffer.alloc(FAST_MIN_BYTES, 1);
+      const tail = Buffer.from('appended-while-downloading');
+      const content = Buffer.concat([head, tail]);
+      const sftp = new FakeTransferSftp({
+        // 第一次 stat 决定走 fastGet，第二次 stat 时文件已变长。
+        statSizes: [head.length, content.length],
+        remoteContent: content,
+        fastGetBytes: head.length,
+      });
+      const tempDir = setupTransfer(sftp);
+      const localFile = path.join(tempDir, 'growing.log');
+
+      await manager.download('/remote/growing.log', localFile, 'exec');
+
+      assert.strictEqual(sftp.fastGetCalls.length, 1);
+      assert.deepStrictEqual(sftp.readStreamCalls[0].options.start, head.length);
+      assert.deepStrictEqual(fs.readFileSync(localFile), content);
     });
   });
 });


### PR DESCRIPTION
## Problem

`upload`/`download` transfer files with `pipeline(fs.createReadStream, sftp.createWriteStream)`. ssh2's SFTP `ReadStream`/`WriteStream` keep a **single request in flight**, so throughput is capped at one chunk per round trip regardless of the available bandwidth. ssh2 says so itself:

```js
// node_modules/ssh2/lib/protocol/SFTP.js:3833
// TODO: add `concurrency` setting to allow more than one in-flight WRITE
// request to server to improve throughput
function WriteStream(sftp, path, options) {
```

`fastGet`/`fastPut` pipeline 64 chunks of 32 KiB instead. On high latency links this is the difference between a transfer being usable and not:

| RTT | streaming | fastGet/fastPut |
|---|---|---|
| 5 ms | ~13 MB/s | bandwidth bound |
| 50 ms | ~1.3 MB/s | ~40 MB/s |
| 200 ms | ~0.3 MB/s | ~10 MB/s |

## Approach

Swapping the call unconditionally is not safe, so the concurrent path is only taken for regular files of at least 256 KiB. Everything else keeps the existing streaming path, byte for byte:

- **Pseudo files.** `fastXfer` plans its chunks from the reported size and hits `if (fsize <= 0) return onerror()` — called with no argument, so the callback receives `undefined` and it looks like success, while the destination was already opened with `w`. Downloading `/proc/cpuinfo` would silently yield an empty file. The size threshold keeps those on the streaming path, which reads to EOF and does not care about the reported size.
- **Failing stat.** A missing file, a directory, or a server without stat support falls back to the streaming path so the error message and code stay exactly what they are today. Only a stat *timeout* surfaces, because `withTimeout` has already torn the connection down. The stat is wrapped in `withTimeout` like every other SFTP operation, so it cannot hang unbounded.
- **`opts.fileSize` is deliberately not passed.** `fastXfer` retries short reads at the same offset (`if (nb < origChunkLen) return singleRead(...)`), so a size larger than the actual file — log rotation, truncation — would spin until the SFTP timeout. Letting ssh2 fstat the handle it just opened keeps that window at one round trip.
- **Files that grow mid-transfer.** `fastGet` transfers exactly the byte count the file had when it started, but the streaming path reads to EOF and would have picked up the tail. The tail is fetched afterwards so both paths stay equivalent for logs that are still being written. On the upload side the local stat is free, so the remote round trip only happens when the file actually grew.
- **`O_EXCL`.** `fastGet` opens the destination with `w`, so the temp file name is claimed with `wx` first, preserving the exclusive-create guarantee the streaming path gets.

Small files stay on the streaming path deliberately: they already complete in a couple of round trips, so the extra stat would cost more than the concurrency saves.

## Trade-off

Peak memory grows with the file size, capped at 2 MiB per transfer (ssh2 shrinks `chunkSize * concurrency` down to the file size — a 256 KiB file allocates 256 KiB with concurrency 8, only files ≥ 2 MiB reach the full 2 MiB with concurrency 64).

No new configuration, no new dependency, transparent to callers.

## Tests

6 new tests covering both branch selection and the failure modes above:

```
✔ 小文件上传仍走顺序流，不触发 fastPut
✔ 大文件上传使用 fastPut 并发传输
✔ 远端 size 为 0 的伪文件走顺序流并拿到真实内容
✔ 远端目录不会走 fastGet
✔ 大文件下载使用 fastGet 并发传输
✔ 下载期间远端文件增长时补齐尾部
```

Mutation-checked: removing the size threshold makes the small-file and pseudo-file tests fail.

Suite goes from 132 to 138 tests, 126 to 132 passing. The 6 failures are unchanged and pre-existing on this Windows dev machine (a test hardcoding `/tmp`, a symlink test needing administrator rights, and a SIGTERM timing test); they fail identically on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)