### PR TITLE
perf: scan shell output incrementally, decode across chunk boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,13 +542,13 @@ npx @fangjunjie/ssh-mcp-server \
 
 ### 📦 命令输出限制
 
-`exec` 模式会限制单条命令捕获的 `stdout` 和 `stderr` 总量，避免大文件或无限输出耗尽 MCP server 内存：
+会限制单条命令捕获的 `stdout` 和 `stderr` 总量，避免大文件或无限输出耗尽 MCP server 内存：
 
 - 在 JSON 连接配置中使用 `maxOutputBytes` 设置上限，默认值为 `10485760`（10 MiB）
 - `maxOutputBytes` 必须是非负整数；设置为 `0` 可禁用限制，但不建议对不受信任的命令禁用
 - 输出超过限制时，远端命令会被中止，工具返回 `OUTPUT_LIMIT_EXCEEDED` 错误和已经捕获的截断输出，不会把中止的命令误报为成功
 - 当 `pty` 为 `false` 时，成功命令写入 `stderr` 的警告或进度信息会保留在 `[stderr]` 区段中
-- 该限制目前仅适用于 `exec` 模式；`shell` 模式不使用 `maxOutputBytes`
+- `exec` 与 `shell` 两种模式都会应用该限制。区别在于 `exec` 模式只关闭该命令的通道，而 `shell` 模式的通道由该连接上的所有命令共用、远端在中止后仍会继续写入，因此会断开连接（与 shell 模式命令超时的处理一致）
 
 ### 🗂️ 列出所有SSH服务器
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -536,13 +536,13 @@ This is particularly useful for commands like `ping`, `tail -f`, or other long-r
 
 ### 📦 Command Output Limit
 
-In `exec` mode, the combined captured `stdout` and `stderr` for each command is limited to protect the MCP server from large files or unbounded output:
+The combined captured `stdout` and `stderr` for each command is limited to protect the MCP server from large files or unbounded output:
 
 - Set `maxOutputBytes` in a JSON connection configuration; the default is `10485760` bytes (10 MiB)
 - `maxOutputBytes` must be a non-negative integer; `0` disables the limit, which is not recommended for untrusted commands
 - When output exceeds the limit, the remote command is aborted and the tool returns an `OUTPUT_LIMIT_EXCEEDED` error with the captured, truncated output instead of reporting success
 - With `pty: false`, warnings and progress written to `stderr` by successful commands are preserved in a `[stderr]` section
-- The limit currently applies only to `exec` mode; `shell` mode does not use `maxOutputBytes`
+- The limit applies to both `exec` and `shell` mode. `exec` mode closes just that command's channel, whereas the `shell` channel is shared by every command on the connection and the remote keeps writing after an abort, so the connection is dropped instead — the same way a shell mode command timeout behaves
 
 ### 🗂️ List All SSH Servers
 

--- a/src/services/ssh-connection-manager.ts
+++ b/src/services/ssh-connection-manager.ts
@@ -12,6 +12,7 @@ import fs from "fs";
 import path from "path";
 import type { Duplex } from "node:stream";
 import { pipeline } from "node:stream/promises";
+import { StringDecoder } from "node:string_decoder";
 
 const require = createRequire(import.meta.url);
 
@@ -27,6 +28,26 @@ type ShellCommandMatch = {
   remainder: string;
 };
 
+/**
+ * Incremental marker scanner state.
+ *
+ * Scanning the accumulated buffer on every chunk is quadratic, and not only
+ * because of the repeated comparisons: `indexOf` needs a flat string, so each
+ * call re-flattens the rope built by the appends and copies the whole buffer
+ * again. `tail` therefore holds just the text that could still start a marker —
+ * the previous scan already ruled out everything before it — so each chunk is
+ * examined once against a short string, and the accumulated buffer is only
+ * touched when a complete marker has been located.
+ *
+ * `tailStart` is the absolute index of `tail[0]` within that buffer, which is
+ * what turns a tail-relative hit back into an absolute position.
+ */
+type ShellScanState = {
+  outputStartIndex: number;
+  tail: string;
+  tailStart: number;
+};
+
 type SshAuthMethod =
   | "none"
   | "password"
@@ -37,6 +58,11 @@ type SshAuthMethod =
 
 const ANSI_OSC_PATTERN = /\u001b\][^\u0007\u001b]*(?:\u0007|\u001b\\)/g;
 const ANSI_CSI_PATTERN = /\u001b\[[0-?]*[ -/]*[@-~]/g;
+
+// Matches the exit code that `buildShellCommandScript` prints right after the
+// end marker prefix, anchored so it can only be read at the expected offset.
+const SHELL_EXIT_CODE_PATTERN = /^(-?\d+)__(?:\r)?\n/;
+const SHELL_EXIT_CODE_MAX_LENGTH = 32;
 
 const COMMAND_TEMPLATE_PLACEHOLDER = "<command>";
 const QUOTED_COMMAND_TEMPLATE_PLACEHOLDER = "<quotedCommand>";
@@ -146,6 +172,9 @@ export class SSHConnectionManager {
   private shellReady: Map<string, boolean> = new Map();
   private shellQueues: Map<string, Promise<unknown>> = new Map();
   private shellBuffers: Map<string, string> = new Map();
+  // A multi-byte character can be split across two TCP chunks, so the channel
+  // needs one decoder for its whole lifetime rather than a decode per chunk.
+  private shellDecoders: Map<string, StringDecoder> = new Map();
   private defaultName: string = "default";
 
   private constructor() {}
@@ -747,6 +776,7 @@ export class SSHConnectionManager {
     this.shellReady.clear();
     this.shellQueues.clear();
     this.shellBuffers.clear();
+    this.shellDecoders.clear();
   }
 
   /**
@@ -1444,6 +1474,10 @@ export class SSHConnectionManager {
           let exitCode: number | undefined;
           let exitSignal: string | undefined;
           let capturedBytes = 0;
+          // Decoding each chunk on its own corrupts any multi-byte character
+          // that happens to be split across a chunk boundary.
+          const stdoutDecoder = new StringDecoder("utf8");
+          const stderrDecoder = new StringDecoder("utf8");
 
           // Without a cap a single command (`cat` on a huge file, an unbounded
           // `journalctl`, ...) can buffer unbounded output in memory until the
@@ -1459,11 +1493,11 @@ export class SSHConnectionManager {
             ) {
               const remaining = maxOutputBytes - capturedBytes;
               if (remaining > 0) {
-                const partial = chunk.subarray(0, remaining).toString();
+                const partial = chunk.subarray(0, remaining);
                 if (isStderr) {
-                  errorData += partial;
+                  errorData += stderrDecoder.write(partial);
                 } else {
-                  data += partial;
+                  data += stdoutDecoder.write(partial);
                 }
               }
               capturedBytes = maxOutputBytes;
@@ -1493,9 +1527,9 @@ export class SSHConnectionManager {
 
             capturedBytes += chunk.length;
             if (isStderr) {
-              errorData += chunk.toString();
+              errorData += stderrDecoder.write(chunk);
             } else {
-              data += chunk.toString();
+              data += stdoutDecoder.write(chunk);
             }
           };
 
@@ -1525,8 +1559,9 @@ export class SSHConnectionManager {
               exitSignal = signal;
             }
 
-            const stdout = data.trimEnd();
-            const stderr = errorData.trimEnd();
+            // Flush any trailing incomplete multi-byte sequence.
+            const stdout = (data + stdoutDecoder.end()).trimEnd();
+            const stderr = (errorData + stderrDecoder.end()).trimEnd();
 
             const hasNonZeroExitCode =
               exitCode !== undefined && exitCode !== 0;
@@ -1641,6 +1676,7 @@ export class SSHConnectionManager {
     this.shellReady.set(key, false);
     this.shellQueues.set(key, Promise.resolve());
     this.shellBuffers.set(key, "");
+    this.shellDecoders.set(key, new StringDecoder("utf8"));
 
     const readyId = this.generateMarkerId("ready");
     const readyMarker = `__MCP_READY__${readyId}__`;
@@ -1712,7 +1748,7 @@ export class SSHConnectionManager {
       };
 
       const onData = (chunk: Buffer) => {
-        this.appendShellBuffer(key, chunk.toString());
+        this.appendShellBuffer(key, chunk);
         resolveIfReady();
       };
 
@@ -1830,9 +1866,19 @@ export class SSHConnectionManager {
     const config = this.getConfig(key);
     const script = this.buildShellCommandScript(commandId, cmdString, directory, config.commandTemplate);
 
+    const maxOutputBytes = this.getMaxOutputBytes(config);
+
     return new Promise<string>((resolve, reject) => {
       let settled = false;
       let timeoutId: NodeJS.Timeout;
+      let capturedBytes = 0;
+      const scanState: ShellScanState = {
+        outputStartIndex: -1,
+        tail: "",
+        // Whatever the previous command left behind cannot hold this command's
+        // markers, so the scan starts past it.
+        tailStart: (this.shellBuffers.get(key) || "").length,
+      };
 
       const cleanup = () => {
         if (timeoutId) {
@@ -1859,8 +1905,11 @@ export class SSHConnectionManager {
       };
 
       const resolveIfComplete = () => {
-        const buffer = this.shellBuffers.get(key) || "";
-        const matched = this.extractShellCommandResult(buffer, commandId);
+        const matched = this.extractShellCommandResult(
+          key,
+          commandId,
+          scanState,
+        );
         if (!matched) {
           return;
         }
@@ -1887,7 +1936,25 @@ export class SSHConnectionManager {
       };
 
       const onData = (chunk: Buffer) => {
-        this.appendShellBuffer(key, chunk.toString());
+        scanState.tail += this.appendShellBuffer(key, chunk);
+        capturedBytes += chunk.length;
+
+        // The shell channel is shared by every command on this connection, so
+        // it cannot simply be closed like an exec channel: the command would
+        // keep writing into the buffer. Drop the connection instead, the same
+        // way the command timeout does.
+        if (maxOutputBytes > 0 && capturedBytes > maxOutputBytes) {
+          this.invalidateConnection(key);
+          finish(
+            new ToolError(
+              "OUTPUT_LIMIT_EXCEEDED",
+              `[truncated] Output exceeded maxOutputBytes=${maxOutputBytes}; the command was aborted.`,
+              false,
+            ),
+          );
+          return;
+        }
+
         resolveIfComplete();
       };
 
@@ -1956,44 +2023,108 @@ export class SSHConnectionManager {
     ].join("\n");
   }
 
-  private extractShellCommandResult(
-    buffer: string,
-    commandId: string,
-  ): ShellCommandMatch | null {
-    const beginMarker = `__MCP_BEGIN__${commandId}__`;
-    const beginIndex = buffer.indexOf(beginMarker);
-    if (beginIndex === -1) {
-      return null;
-    }
-
-    const beginLineEndIndex = buffer.indexOf("\n", beginIndex);
-    if (beginLineEndIndex === -1) {
-      return null;
-    }
-
-    const outputStartIndex = beginLineEndIndex + 1;
-    const tail = buffer.slice(outputStartIndex);
-    const endRegex = new RegExp(
-      `__MCP_END__${this.escapeRegExp(commandId)}__RC__(-?\\d+)__(?:\\r)?\\n`,
+  /**
+   * Drop the part of the tail that can no longer start a marker: a marker only
+   * straddles the boundary of the chunk that just arrived, so keeping the last
+   * `markerLength - 1` characters is enough.
+   */
+  private trimShellScanTail(
+    scanState: ShellScanState,
+    markerLength: number,
+  ): void {
+    this.advanceShellScanTail(
+      scanState,
+      scanState.tail.length - Math.min(scanState.tail.length, markerLength - 1),
     );
-    const matched = endRegex.exec(tail);
-    if (!matched) {
+  }
+
+  private advanceShellScanTail(
+    scanState: ShellScanState,
+    offset: number,
+  ): void {
+    if (offset <= 0) {
+      return;
+    }
+    scanState.tailStart += offset;
+    scanState.tail = scanState.tail.slice(offset);
+  }
+
+  /**
+   * Locate a finished command, scanning only the freshly arrived tail. The
+   * accumulated buffer is read once, after the whole end marker is in hand.
+   */
+  private extractShellCommandResult(
+    key: string,
+    commandId: string,
+    scanState: ShellScanState,
+  ): ShellCommandMatch | null {
+    if (scanState.outputStartIndex === -1) {
+      const beginMarker = `__MCP_BEGIN__${commandId}__`;
+      const beginIndex = scanState.tail.indexOf(beginMarker);
+      if (beginIndex === -1) {
+        this.trimShellScanTail(scanState, beginMarker.length);
+        return null;
+      }
+
+      const beginLineEndIndex = scanState.tail.indexOf("\n", beginIndex);
+      if (beginLineEndIndex === -1) {
+        this.advanceShellScanTail(scanState, beginIndex);
+        return null;
+      }
+
+      this.advanceShellScanTail(scanState, beginLineEndIndex + 1);
+      scanState.outputStartIndex = scanState.tailStart;
+    }
+
+    // Search the fixed prefix rather than the whole pattern: its length is
+    // known, which is what makes the retained overlap provably sufficient. The
+    // exit code is then parsed from the short slice that follows it.
+    const endPrefix = `__MCP_END__${commandId}__RC__`;
+    const endIndex = scanState.tail.indexOf(endPrefix);
+    if (endIndex === -1) {
+      this.trimShellScanTail(scanState, endPrefix.length);
       return null;
     }
 
-    const endIndex = outputStartIndex + matched.index;
-    const consumedEndIndex = endIndex + matched[0].length;
+    const exitCodeStart = endIndex + endPrefix.length;
+    const matched = SHELL_EXIT_CODE_PATTERN.exec(
+      scanState.tail.slice(
+        exitCodeStart,
+        exitCodeStart + SHELL_EXIT_CODE_MAX_LENGTH,
+      ),
+    );
+    if (!matched) {
+      // The prefix arrived but the exit code has not; resume from here.
+      this.advanceShellScanTail(scanState, endIndex);
+      return null;
+    }
+
+    const buffer = this.shellBuffers.get(key) || "";
+    const absoluteEndIndex = scanState.tailStart + endIndex;
+    const consumedEndIndex =
+      absoluteEndIndex + endPrefix.length + matched[0].length;
 
     return {
-      output: buffer.slice(outputStartIndex, endIndex),
+      output: buffer.slice(scanState.outputStartIndex, absoluteEndIndex),
       exitCode: Number.parseInt(matched[1], 10),
       remainder: buffer.slice(consumedEndIndex),
     };
   }
 
-  private appendShellBuffer(key: string, chunk: string): void {
+  /** Appends the decoded chunk and returns just that text. */
+  private appendShellBuffer(key: string, chunk: Buffer): string {
+    let decoder = this.shellDecoders.get(key);
+    if (!decoder) {
+      decoder = new StringDecoder("utf8");
+      this.shellDecoders.set(key, decoder);
+    }
+
+    // Concatenation alone stays cheap; it is reading the result that forces the
+    // rope to flatten, so nothing here may inspect the accumulated buffer.
+    const text = decoder.write(chunk);
     const current = this.shellBuffers.get(key) || "";
-    this.shellBuffers.set(key, current + chunk);
+    this.shellBuffers.set(key, current + text);
+    return text;
   }
 
   private cleanShellOutput(output: string): string {
@@ -2022,10 +2153,6 @@ export class SSHConnectionManager {
     return `${prefix}_${Date.now()}_${Math.random().toString(16).slice(2, 10)}`;
   }
 
-  private escapeRegExp(input: string): string {
-    return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  }
-
   private cleanupShellState(key: string, closeStream: boolean = false): void {
     const stream = this.shellStreams.get(key);
     if (closeStream && stream) {
@@ -2040,6 +2167,7 @@ export class SSHConnectionManager {
     this.shellReady.delete(key);
     this.shellQueues.delete(key);
     this.shellBuffers.delete(key);
+    this.shellDecoders.delete(key);
   }
 
   private clearConnectionState(key: string): void {

--- a/test/ssh-connection-manager.test.js
+++ b/test/ssh-connection-manager.test.js
@@ -1619,4 +1619,163 @@ describe('SSH Connection Manager', () => {
       assert.strictEqual(result, 'done');
     });
   });
+
+  describe('输出解码与上限', () => {
+    // Emit `payload` in fixed-size byte slices so multi-byte characters and
+    // markers are split across chunk boundaries.
+    function emitInByteSlices(emit, payload, sliceSize) {
+      const bytes = Buffer.from(payload, 'utf8');
+      for (let i = 0; i < bytes.length; i += sliceSize) {
+        emit(bytes.subarray(i, i + sliceSize));
+      }
+    }
+
+    async function connectShell(channel, overrides = {}) {
+      channel.on('write', (payload) => {
+        const readyId = extractMarkerId(payload, '__MCP_READY__');
+        if (readyId) {
+          setImmediate(() => {
+            channel.emit('data', Buffer.from(`__MCP_READY__${readyId}__\n`));
+          });
+        }
+      });
+
+      const client = new FakeClient({
+        onConnect: () => setImmediate(() => client.emit('ready')),
+        onShell: ({ callback }) => callback(undefined, channel),
+      });
+
+      manager.createClient = () => client;
+      manager.scheduleStatusCollection = () => {};
+      manager.setConfig({
+        shell: createPasswordConfig({ transportMode: 'shell', ...overrides }),
+      });
+
+      await manager.connect('shell');
+      return client;
+    }
+
+    it('exec 模式跨块的多字节字符不会损坏', async () => {
+      const text = '中文输出测试内容';
+      const stream = new FakeExecStream();
+      const client = new FakeClient({
+        onConnect: () => setImmediate(() => client.emit('ready')),
+        onExec: ({ callback }) => {
+          callback(undefined, stream);
+          setImmediate(() => {
+            emitInByteSlices(
+              (slice) => stream.emit('data', slice),
+              text,
+              5,
+            );
+            stream.emit('exit', 0);
+            stream.emit('close', 0);
+          });
+        },
+      });
+
+      manager.createClient = () => client;
+      manager.scheduleStatusCollection = () => {};
+      manager.setConfig({
+        exec: createPasswordConfig({ name: 'exec', transportMode: 'exec' }),
+      });
+
+      assert.strictEqual(
+        await manager.executeCommand('cat zh.txt', undefined, 'exec'),
+        text,
+      );
+    });
+
+    it('shell 模式跨块的多字节字符与 marker 都能正确还原', async () => {
+      const text = '中文输出测试内容';
+      const channel = new FakeShellChannel();
+      let commandId;
+      channel.on('write', (payload) => {
+        commandId = extractMarkerId(payload, '__MCP_BEGIN__') ?? commandId;
+      });
+
+      await connectShell(channel);
+      const pending = manager.executeCommand('cat zh.txt', undefined, 'shell');
+      await delay(0);
+
+      // 5 字节一片：既切断多字节字符，也切断 marker 本身
+      emitInByteSlices(
+        (slice) => channel.emit('data', slice),
+        `__MCP_BEGIN__${commandId}__\r\n${text}\n__MCP_END__${commandId}__RC__0__\r\n`,
+        5,
+      );
+
+      assert.strictEqual(await pending, text);
+    });
+
+    it('shell 模式 marker 逐字节到达仍能识别', async () => {
+      const channel = new FakeShellChannel();
+      let commandId;
+      channel.on('write', (payload) => {
+        commandId = extractMarkerId(payload, '__MCP_BEGIN__') ?? commandId;
+      });
+
+      await connectShell(channel);
+      const pending = manager.executeCommand('echo hi', undefined, 'shell');
+      await delay(0);
+
+      emitInByteSlices(
+        (slice) => channel.emit('data', slice),
+        `__MCP_BEGIN__${commandId}__\r\nhi\n__MCP_END__${commandId}__RC__0__\r\n`,
+        1,
+      );
+
+      assert.strictEqual(await pending, 'hi');
+    });
+
+    it('shell 模式退出码晚于 marker 前缀到达仍能识别', async () => {
+      const channel = new FakeShellChannel();
+      let commandId;
+      channel.on('write', (payload) => {
+        commandId = extractMarkerId(payload, '__MCP_BEGIN__') ?? commandId;
+      });
+
+      await connectShell(channel);
+      const pending = manager.executeCommand('false', undefined, 'shell');
+      await delay(0);
+
+      channel.emit(
+        'data',
+        Buffer.from(`__MCP_BEGIN__${commandId}__\r\noops\n__MCP_END__${commandId}__RC__`),
+      );
+      await delay(0);
+      channel.emit('data', Buffer.from('3__\r\n'));
+
+      await assert.rejects(pending, (error) => {
+        assert.strictEqual(error.code, 'COMMAND_EXECUTION_ERROR');
+        assert.match(error.message, /\[exit code\] 3/);
+        return true;
+      });
+    });
+
+    it('shell 模式超出 maxOutputBytes 会中止命令并失效连接', async () => {
+      const channel = new FakeShellChannel();
+      let commandId;
+      channel.on('write', (payload) => {
+        commandId = extractMarkerId(payload, '__MCP_BEGIN__') ?? commandId;
+      });
+
+      const client = await connectShell(channel, { maxOutputBytes: 1024 });
+      const pending = manager.executeCommand('yes', undefined, 'shell');
+      await delay(0);
+
+      channel.emit('data', Buffer.from(`__MCP_BEGIN__${commandId}__\r\n`));
+      channel.emit('data', Buffer.alloc(4096, 0x78));
+
+      await assert.rejects(pending, (error) => {
+        assert.ok(error instanceof ToolError);
+        assert.strictEqual(error.code, 'OUTPUT_LIMIT_EXCEEDED');
+        assert.match(error.message, /maxOutputBytes=1024/);
+        return true;
+      });
+
+      assert.strictEqual(manager.getAllServerInfos()[0].connected, false);
+      assert.strictEqual(client.endCalls, 1);
+    });
+  });
 });


### PR DESCRIPTION
Three fixes to the command output path. They are in the same code and overlap in tests, so they come as one change.

## 1. Shell transport rescanned the whole buffer on every chunk

`executeShellCommand` called `extractShellCommandResult(buffer, ...)` for each arriving chunk, and that walked the entire accumulated output from index 0 — `indexOf` for the begin marker, `buffer.slice(outputStartIndex)` copying the whole tail, and a freshly compiled `RegExp` for the end marker.

The repeated comparisons are the smaller half of the cost. The larger half is that `indexOf` needs a flat string, so every call re-flattened the rope built by the appends and copied the entire buffer again. Adding a resume offset alone barely helps for that reason — measured 3350 ms → 2326 ms on 8 MB.

Scanning only the freshly arrived tail fixes it. A marker can only straddle the boundary of the chunk that just arrived, so keeping the last `markerLength - 1` characters is sufficient; everything before that was already ruled out. The accumulated buffer is read exactly once, after the whole end marker is in hand.

Measured through the real code path (fake channel, 8 KiB chunks):

| shell output | before | after |
|---|---|---|
| 2 MB | 153 ms | 8 ms |
| 4 MB | 897 ms | 16 ms |
| 8 MB | 3479 ms | 30 ms |

The end marker is now located by its fixed-length prefix rather than a whole pattern, which is what makes the retained overlap provably sufficient; the exit code is parsed from the short slice that follows. `escapeRegExp` goes away with the per-chunk `RegExp` construction that used it.

## 2. Multi-byte characters split across chunks were corrupted

Both transports decoded each chunk on its own with `chunk.toString()`. A character split across a TCP chunk boundary becomes U+FFFD:

```
"中文输出测试" -> "中��输���测试"
```

A `StringDecoder` carries the partial sequence to the next chunk instead. exec mode gets one decoder per stdout/stderr stream; the shell decoder lives as long as the channel, because a character can also be split across the boundary between two commands.

## 3. Shell transport ignored `maxOutputBytes`

The cap was only applied in `runExecCommand`, so in shell mode a single unbounded command (`journalctl` without limits, `cat` on a large file) buffered without limit. Combined with the quadratic scan above, that was the worst case.

It now aborts the same way exec mode does. The one difference: an exec channel can simply be closed, but the shell channel is shared by every command on the connection and the remote keeps writing after an abort, so the connection is dropped instead — which is what the shell command timeout already does.

## Tests

5 new tests:

```
✔ exec 模式跨块的多字节字符不会损坏
✔ shell 模式跨块的多字节字符与 marker 都能正确还原
✔ shell 模式 marker 逐字节到达仍能识别
✔ shell 模式退出码晚于 marker 前缀到达仍能识别
✔ shell 模式超出 maxOutputBytes 会中止命令并失效连接
```

The marker tests feed the payload in 5-byte and 1-byte slices, so markers and characters are split in the worst possible places.

Mutation-checked, each mutation caught by exactly the test that should catch it:

| mutation | result |
|---|---|
| exec back to per-chunk `toString()` | exec decode test fails |
| shell back to per-chunk `toString()` | shell decode test fails |
| output cap removed | cap test hangs to the command timeout |
| tail overlap set to 0 | both marker-split tests hang, marker never found |

Suite goes from 132 to 137 tests, 126 to 131 passing. The 6 failures are unchanged and pre-existing on this Windows dev machine (a test hardcoding `/tmp`, a symlink test needing administrator rights, and a SIGTERM timing test); they fail identically on `main`.

Independent of #72 — both branch from `main` and touch different parts of the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)