### PR TITLE
perf: collect server status in a single remote command

### DIFF
--- a/src/utils/status-collector.ts
+++ b/src/utils/status-collector.ts
@@ -7,6 +7,46 @@ type StatusCommandRunner = (
 ) => Promise<string>;
 
 /**
+ * Join the probes into a single remote command, each result introduced by a
+ * marker line.
+ *
+ * Running them separately costs one SSH channel per probe — open, pty request,
+ * exec and close, several round trips each — plus a remote shell per probe. In
+ * shell transport it is worse still: the per-connection queue serialises them,
+ * so the first command the user issues after connecting waits behind all of
+ * them.
+ *
+ * Every probe is wrapped so that a missing tool or a non-zero exit cannot
+ * abort the rest, and the whole script ends successfully.
+ */
+function buildStatusScript(
+  commands: Record<string, string>,
+  marker: string,
+): string {
+  const probes = Object.entries(commands).map(
+    ([field, command]) =>
+      `printf '\\n${marker}${field}\\n'; { ${command}; } 2>/dev/null`,
+  );
+  return `${probes.join("; ")}; true`;
+}
+
+function parseStatusScriptOutput(
+  output: string,
+  marker: string,
+): Map<string, string> {
+  const values = new Map<string, string>();
+  const normalized = output.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  // Splitting on a capturing group yields [before, field, value, field, ...].
+  const segments = normalized.split(new RegExp(`\\n?${marker}(\\w+)\\n`));
+
+  for (let index = 1; index < segments.length; index += 2) {
+    values.set(segments[index], (segments[index + 1] ?? "").trim());
+  }
+
+  return values;
+}
+
+/**
  * Collect system status information from remote server
  */
 export async function collectSystemStatus(
@@ -19,35 +59,7 @@ export async function collectSystemStatus(
   };
 
   try {
-    const runCommandsWithConcurrencyLimit = async (
-      commands: string[],
-      limit: number,
-    ): Promise<string[]> => {
-      const results = new Array<string>(commands.length).fill("");
-      let nextIndex = 0;
-
-      const worker = async (): Promise<void> => {
-        while (nextIndex < commands.length) {
-          const currentIndex = nextIndex++;
-          try {
-            results[currentIndex] = await runCommand(
-              commands[currentIndex],
-              connectionName,
-            );
-          } catch {
-            results[currentIndex] = "";
-          }
-        }
-      };
-
-      const workerCount = Math.min(limit, commands.length);
-      await Promise.all(
-        Array.from({ length: workerCount }, async () => worker()),
-      );
-
-      return results;
-    };
-    // Collect all status information in parallel where possible
+    // Collected in a single remote command; see buildStatusScript.
     const commands = {
       hostname: "hostname",
       ipAddresses: "ip -o addr show | awk '{print $4}' | grep -v '^127\\.' | cut -d'/' -f1",
@@ -69,50 +81,41 @@ export async function collectSystemStatus(
       servicesInstalled: "systemctl list-unit-files --type=service 2>/dev/null | wc -l || ls /etc/init.d/ 2>/dev/null | wc -l || echo '0'",
     };
 
-    // Execute commands and collect results
-    const resultValues = await runCommandsWithConcurrencyLimit(
-      [
-        commands.hostname,
-        commands.ipAddresses,
-        commands.osName,
-        commands.osVersion,
-        commands.kernelVersion,
-        commands.uptime,
-        commands.diskSpace,
-        commands.memory,
-        commands.cpuName,
-        commands.cpuUsage,
-        commands.gpus,
-        commands.gpuPaths,
-        commands.drives,
-        commands.processes,
-        commands.threads,
-        commands.servicesRunning,
-        commands.servicesInstalled,
-      ],
-      3,
-    );
+    // Execute the probes and collect results
+    const marker = `__MCP_FIELD_${Math.random().toString(16).slice(2, 10)}_`;
+    let values = new Map<string, string>();
+    try {
+      values = parseStatusScriptOutput(
+        await runCommand(buildStatusScript(commands, marker), connectionName),
+        marker,
+      );
+    } catch {
+      // A rejected command (an unreachable host, a command whitelist that does
+      // not admit the probe) leaves every field unset, the same as when the
+      // probes ran separately and each failed on its own.
+    }
 
     // Parse results
-    const [
-      hostnameValue,
-      ipAddressesValue,
-      osNameValue,
-      osVersionValue,
-      kernelVersionValue,
-      uptimeValue,
-      diskSpaceValue,
-      memoryValue,
-      cpuNameValue,
-      cpuUsageValue,
-      gpusValue,
-      gpuPathsValue,
-      drivesValue,
-      processesValue,
-      threadsValue,
-      servicesRunningValue,
-      servicesInstalledValue,
-    ] = resultValues;
+    const readField = (field: keyof typeof commands): string =>
+      values.get(field) ?? "";
+
+    const hostnameValue = readField("hostname");
+    const ipAddressesValue = readField("ipAddresses");
+    const osNameValue = readField("osName");
+    const osVersionValue = readField("osVersion");
+    const kernelVersionValue = readField("kernelVersion");
+    const uptimeValue = readField("uptime");
+    const diskSpaceValue = readField("diskSpace");
+    const memoryValue = readField("memory");
+    const cpuNameValue = readField("cpuName");
+    const cpuUsageValue = readField("cpuUsage");
+    const gpusValue = readField("gpus");
+    const gpuPathsValue = readField("gpuPaths");
+    const drivesValue = readField("drives");
+    const processesValue = readField("processes");
+    const threadsValue = readField("threads");
+    const servicesRunningValue = readField("servicesRunning");
+    const servicesInstalledValue = readField("servicesInstalled");
 
     if (hostnameValue) {
       status.hostname = hostnameValue;

--- a/test/status-collector.test.js
+++ b/test/status-collector.test.js
@@ -1,0 +1,124 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { collectSystemStatus } from '../build/utils/status-collector.js';
+
+const PROBE_PATTERN = /printf '\\n(__MCP_FIELD_\w+_)(\w+)\\n'/g;
+
+/** Field names in the order the script probes them, plus the shared marker. */
+function readProbes(script) {
+  const probes = [...script.matchAll(PROBE_PATTERN)];
+  return {
+    marker: probes[0]?.[1],
+    fields: probes.map((probe) => probe[2]),
+  };
+}
+
+/**
+ * Stand-in for the remote shell: emits the marker line for every probe the
+ * script declares, followed by whatever `values` supplies for it.
+ */
+function fakeRemote(values, { lineEnding = '\n' } = {}) {
+  return (script) => {
+    const { marker, fields } = readProbes(script);
+    const output = fields
+      .map((field) => `${marker}${field}${lineEnding}${values[field] ?? ''}`)
+      .join(lineEnding);
+    return Promise.resolve(lineEnding + output);
+  };
+}
+
+describe('status collector', () => {
+  it('所有探针合并为一条单行命令', async () => {
+    const scripts = [];
+    await collectSystemStatus((script) => {
+      scripts.push(script);
+      return Promise.resolve('');
+    }, 'dev');
+
+    assert.strictEqual(scripts.length, 1);
+    // 多行脚本会被 commandTemplate 的引号包裹破坏
+    assert.ok(!scripts[0].includes('\n'));
+    // 每个探针都被隔离，单个失败不影响其余，且整体以成功退出
+    assert.ok(scripts[0].endsWith('; true'));
+
+    const { fields } = readProbes(scripts[0]);
+    assert.ok(fields.includes('hostname'));
+    assert.ok(fields.includes('servicesInstalled'));
+    assert.strictEqual(new Set(fields).size, fields.length);
+  });
+
+  it('按 marker 还原各字段', async () => {
+    const status = await collectSystemStatus(
+      fakeRemote({
+        hostname: 'web-01',
+        osName: 'Linux',
+        kernelVersion: '6.1.0',
+        memory: 'free:2.1G total:7.7G',
+        processes: '181',
+        threads: '901',
+      }),
+      'dev',
+    );
+
+    assert.strictEqual(status.reachable, true);
+    assert.strictEqual(status.hostname, 'web-01');
+    assert.strictEqual(status.osName, 'Linux');
+    assert.strictEqual(status.kernelVersion, '6.1.0');
+    assert.deepStrictEqual(status.memory, { free: '2.1G', total: '7.7G' });
+    // 解析时会各减去一行表头
+    assert.deepStrictEqual(status.processes, { running: 180, threads: 900 });
+  });
+
+  // 多行字段是 CRLF 归一化真正起作用的地方：逐行拆分的值不会再单独 trim，
+  // 残留的 \r 会直接进入结果。
+  it('pty 的 CRLF 输出同样能解析', async () => {
+    const status = await collectSystemStatus(
+      fakeRemote(
+        {
+          hostname: 'web-02',
+          ipAddresses: '10.0.0.7\r\n192.168.1.5',
+          drives: '/dev/sda1|50G|20G|30G|40%|/',
+        },
+        { lineEnding: '\r\n' },
+      ),
+      'dev',
+    );
+
+    assert.strictEqual(status.hostname, 'web-02');
+    assert.deepStrictEqual(status.ipAddresses, ['10.0.0.7', '192.168.1.5']);
+    assert.deepStrictEqual(status.drives, [
+      {
+        device: '/dev/sda1',
+        total: '50G',
+        used: '20G',
+        free: '30G',
+        usagePercent: '40%',
+        mountPoint: '/',
+      },
+    ]);
+  });
+
+  it('空探针不影响其它字段', async () => {
+    const status = await collectSystemStatus(
+      fakeRemote({ hostname: 'web-03', ipAddresses: '', osName: 'Linux' }),
+      'dev',
+    );
+
+    assert.strictEqual(status.hostname, 'web-03');
+    assert.strictEqual(status.osName, 'Linux');
+    assert.strictEqual(status.ipAddresses, undefined);
+  });
+
+  // 命令白名单会拒绝这条探针脚本；那种情况下字段留空即可，
+  // 不能把主机报成不可达。
+  it('命令被拒绝时字段留空但仍视为可达', async () => {
+    const status = await collectSystemStatus(
+      () => Promise.reject(new Error('Command validation failed')),
+      'dev',
+    );
+
+    assert.strictEqual(status.reachable, true);
+    assert.strictEqual(status.hostname, undefined);
+    assert.ok(status.lastUpdated);
+  });
+});


### PR DESCRIPTION
## Problem

`collectSystemStatus` runs 17 probes as 17 separate commands with a concurrency of 3, fired one second after every successful connect.

In exec transport each probe costs its own SSH channel — `CHANNEL_OPEN` + confirmation, `pty-req` with `want_reply`, `exec` with `want_reply`, then close — so roughly 3-4 round trips before any output. Six waves of three gives about 24 round trips: on a 100 ms link that is a couple of seconds of the connection spent on data nobody has asked for yet. The remote side pays too, spawning 17 shells for probes that include `top -bn1`, `ps -eLf`, `lspci` and `nvidia-smi`.

Shell transport is worse. `enqueueShellCommand` serialises every command on a connection, so the concurrency limit of 3 does nothing and the 17 probes run back to back — and the first command the user issues after connecting waits behind all of them.

## Change

The probes are joined into one command, each result introduced by a marker line carrying a per-collection random token:

```sh
printf '\n__MCP_FIELD_a1b2c3d4_hostname\n'; { hostname; } 2>/dev/null; printf '\n__MCP_FIELD_a1b2c3d4_ipAddresses\n'; { ip -o addr ...; } 2>/dev/null; ...; true
```

24 round trips become 3-4, 17 remote shells become one, and the shell transport queue holds one entry instead of 17. The probe commands themselves are unchanged, so the collected fields are the same.

Two details worth calling out:

- **Single line, deliberately.** `commandTemplate` wraps the command in quotes for bastion setups, and a multi-line script would not survive that. A test asserts the script contains no newline.
- **Isolation.** Each probe is wrapped in `{ ...; } 2>/dev/null` so a missing tool or a non-zero exit cannot abort the rest, and the script ends with `; true` so the overall exit status is success regardless of what the last probe did.

Failure handling is unchanged: when the whole command is rejected — an unreachable host, or a command whitelist that does not admit the probe script — every field is left unset and the host is still reported as reachable, exactly as when the probes ran separately and each failed on its own. The existing `状态采集命令不应绕过命令白名单` test covers that path and still passes.

## Verification

Ran the generated script against a real POSIX shell, on a host missing most of the probed tools:

```
runCommand 调用次数: 1
脚本是否单行     : true
```

`hostname`, `uname -s`, `uname -r`, `df` and `nvidia-smi` came back populated; `ip`, `/etc/os-release` and `uptime -p` are absent there and left their fields empty without disturbing the others.

## Tests

New `test/status-collector.test.js`:

```
✔ 所有探针合并为一条单行命令
✔ 按 marker 还原各字段
✔ pty 的 CRLF 输出同样能解析
✔ 空探针不影响其它字段
✔ 命令被拒绝时字段留空但仍视为可达
```

Mutation-checked:

| mutation | result |
|---|---|
| drop the trailing `; true` | single-command test fails |
| let a rejected command propagate | both the new reachability test and the existing whitelist test fail |
| drop the CRLF normalisation | CRLF test fails (multi-line fields such as `ipAddresses` are split per line and not trimmed individually, so a stray `\r` would end up in the result) |

Suite goes from 132 to 137 tests, 126 to 131 passing. The 6 failures are unchanged and pre-existing on this Windows dev machine (a test hardcoding `/tmp`, a symlink test needing administrator rights, and a SIGTERM timing test); they fail identically on `main`.

Independent of #72 and #73 — all three branch from `main` and touch different files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)