### PR TITLE
perf: emit the list-servers JSON without indentation

### DIFF
--- a/src/tools/list-servers.ts
+++ b/src/tools/list-servers.ts
@@ -34,7 +34,9 @@ export function formatServerList(servers: ServerInfo[]): string {
     ...summary,
     "",
     "Raw JSON:",
-    JSON.stringify(servers, null, 2),
+    // Not indented: the pretty printed form is roughly 40% larger for the same
+    // data, and this output is fed to a model rather than read as a document.
+    JSON.stringify(servers),
   ].join("\n");
 }
 

--- a/test/list-servers.test.js
+++ b/test/list-servers.test.js
@@ -28,6 +28,41 @@ describe('List Servers Tool', () => {
     assert.match(output, /\[connected\] dev \| root@192.168.1.100:22/);
     assert.match(output, /hostname=dev-box/);
     assert.match(output, /Raw JSON:/);
-    assert.match(output, /"name": "dev"/);
+    assert.match(output, /"name":"dev"/);
+  });
+
+  it('原始 JSON 不缩进，且仍可解析回等价对象', () => {
+    const servers = [
+      {
+        name: 'dev',
+        host: '192.168.1.100',
+        port: 22,
+        username: 'root',
+        connected: true,
+        status: {
+          reachable: true,
+          hostname: 'dev-box',
+          osName: 'Linux',
+          drives: [
+            {
+              device: '/dev/sda1',
+              mountPoint: '/',
+              total: '512G',
+              used: '380G',
+              free: '106G',
+              usagePercent: '78%',
+            },
+          ],
+          lastUpdated: '2026-04-02T12:00:00.000Z',
+        },
+      },
+    ];
+
+    const rawJson = formatServerList(servers).split('\nRaw JSON:\n')[1];
+
+    assert.deepStrictEqual(JSON.parse(rawJson), servers);
+    // 缩进换行是这里的主要体积来源，压缩后应只剩一行
+    assert.ok(!rawJson.includes('\n'));
+    assert.ok(rawJson.length < JSON.stringify(servers, null, 2).length * 0.7);
   });
 });


### PR DESCRIPTION
`list-servers` returns a readable summary followed by the same data as JSON. The JSON was pretty printed with `JSON.stringify(servers, null, 2)`, which for status-bearing entries is roughly 37% larger than the compact form and turns a handful of lines into hundreds:

| servers | before | after |
|---|---|---|
| 1 | 1580 chars, 70 lines | 1004 chars, 5 lines |
| 3 | 4666 chars, 200 lines | 2940 chars, 7 lines |
| 10 | 15471 chars, 655 lines | 9720 chars, 14 lines |

This output goes to a model rather than being read as a document, so the indentation is paid for on every call and buys nothing. Each indented line also costs a token of its own, so the line count matters as much as the character count.

The human-readable summary above it is untouched — that part is 7% of the output and is what makes the result skimmable. Only the raw JSON block changes, and it still parses back to an equivalent object.

## Scope

Deliberately just this. I looked at whether the summary and the JSON duplicate enough to drop one of them: they overlap on name, host, port, username, connected, hostname, os and lastUpdated, but the JSON also carries cpu, memory, drives, gpus, ipAddresses, processes and services that the summary omits. Removing either one loses something, and the summary is small enough that it is not worth trimming.

## Tests

The existing assertion moved from `"name": "dev"` to `"name":"dev"`, plus one new test:

```
✔ 原始 JSON 不缩进，且仍可解析回等价对象
```

It round-trips through `JSON.parse` to confirm nothing is lost, asserts the block is a single line, and asserts it is under 70% of the pretty printed size. Mutation-checked: restoring `null, 2` fails both that test and the existing one.

Suite goes from 132 to 133 tests, 126 to 127 passing. The 6 failures are unchanged and pre-existing on this Windows dev machine (a test hardcoding `/tmp`, a symlink test needing administrator rights, and a SIGTERM timing test); they fail identically on `main`.

Independent of #72, #73 and #74 — all four branch from `main` and touch different files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)