### PR TITLE
test: make the suite pass on Windows

### DIFF
--- a/test/command-line-parser.test.js
+++ b/test/command-line-parser.test.js
@@ -369,7 +369,9 @@ Host minimalhost
       assert.strictEqual(result.configs.default.host, '172.16.0.1');
       assert.strictEqual(result.configs.default.port, 2222);
       assert.strictEqual(result.configs.default.username, 'testuser');
-      assert.ok(result.configs.default.privateKey.includes('.ssh/test_key'));
+      assert.ok(
+        result.configs.default.privateKey.endsWith(path.join('.ssh', 'test_key')),
+      );
     });
 
     it('命令行参数应覆盖 SSH config 值', () => {
@@ -486,7 +488,7 @@ Host minimalhost
 
       assert.ok(Array.isArray(result.configs.default.allowedLocalPaths));
       assert.strictEqual(result.configs.default.allowedLocalPaths.length, 2);
-      assert.ok(result.configs.default.allowedLocalPaths.every((entry) => entry.startsWith('/')));
+      assert.ok(result.configs.default.allowedLocalPaths.every((entry) => path.isAbsolute(entry)));
       assert.strictEqual(result.configs.default.allowedLocalPaths[1], path.join(os.homedir(), '.ssh'));
     });
 

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -108,7 +108,11 @@ function spawnServer(configPath) {
 }
 
 describe('MCP server lifecycle', () => {
-  it('exits after SIGTERM even when stdin remains open', async () => {
+  // Windows has no POSIX signals: child.kill('SIGTERM') maps to
+  // TerminateProcess, so the handler under test never runs and the exit is
+  // always reported as signalled. The stdin path below covers shutdown there,
+  // and is what MCP clients actually use.
+  it('exits after SIGTERM even when stdin remains open', { skip: process.platform === 'win32' && 'no POSIX signals on Windows' }, async () => {
     const { tmpDir, configPath } = createTempConfig();
     const { child, closeInput } = spawnServer(configPath);
 
@@ -155,6 +159,9 @@ describe('MCP server lifecycle', () => {
     const sockets = new Set();
     handshakeServer.on('connection', (socket) => {
       sockets.add(socket);
+      // Killing the child resets this connection instead of closing it
+      // cleanly on some platforms; an unhandled 'error' would fail the test.
+      socket.on('error', () => {});
       socket.on('close', () => sockets.delete(socket));
     });
 

--- a/test/ssh-connection-manager.test.js
+++ b/test/ssh-connection-manager.test.js
@@ -269,15 +269,25 @@ describe('SSH Connection Manager', () => {
     });
 
     it('应允许配置的本地路径用于传输', () => {
-      manager.setConfig({
-        dev: createPasswordConfig({
-          name: 'dev',
-          allowedLocalPaths: ['/tmp'],
-        }),
-      });
+      const allowedRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ssh-mcp-allowed-'));
 
-      assert.throws(() => manager.validateLocalPath('/etc/passwd'), ToolError);
-      assert.strictEqual(manager.validateLocalPath('/tmp/test.txt'), '/tmp/test.txt');
+      try {
+        manager.setConfig({
+          dev: createPasswordConfig({
+            name: 'dev',
+            allowedLocalPaths: [allowedRoot],
+          }),
+        });
+
+        const insidePath = path.join(allowedRoot, 'test.txt');
+        assert.strictEqual(manager.validateLocalPath(insidePath, 'dev'), insidePath);
+        assert.throws(
+          () => manager.validateLocalPath(path.resolve(path.sep, 'etc', 'passwd'), 'dev'),
+          ToolError,
+        );
+      } finally {
+        fs.rmSync(allowedRoot, { recursive: true, force: true });
+      }
     });
 
     it('本地允许路径应按连接隔离', () => {
@@ -308,7 +318,7 @@ describe('SSH Connection Manager', () => {
       }
     });
 
-    it('本地路径校验应拒绝通过符号链接逃出允许目录', () => {
+    it('本地路径校验应拒绝通过符号链接逃出允许目录', (t) => {
       const allowedRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ssh-mcp-allowed-'));
       const outsideRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ssh-mcp-outside-'));
       const outsideFile = path.join(outsideRoot, 'secret.txt');
@@ -316,7 +326,17 @@ describe('SSH Connection Manager', () => {
 
       try {
         fs.writeFileSync(outsideFile, 'secret');
-        fs.symlinkSync(outsideRoot, symlinkPath, 'dir');
+        try {
+          fs.symlinkSync(outsideRoot, symlinkPath, 'dir');
+        } catch (error) {
+          // Windows only allows this for administrators or with developer
+          // mode enabled; the assertion below is meaningless without a symlink.
+          if (error.code !== 'EPERM' && error.code !== 'EACCES') {
+            throw error;
+          }
+          t.skip('creating symlinks requires elevated privileges here');
+          return;
+        }
 
         manager.setConfig({
           dev: createPasswordConfig({


### PR DESCRIPTION
Six tests fail on Windows. **None of them points at a defect in the server** — `exits after stdin is closed` passes there, and closing stdin is how MCP clients actually terminate it. Four are assertions that assume POSIX, and two depend on capabilities Windows does not offer.

| | Windows | clean Linux |
|---|---|---|
| `main` | 126 pass, **6 fail** | 132 pass, 0 fail |
| this branch | **130 pass, 0 fail, 2 skipped** | 132 pass, 0 fail, **0 skipped** |

## Portability fixes

All four remain meaningful on POSIX; three of them get slightly stricter.

| test | assumption | fix |
|---|---|---|
| `应该从 SSH config 读取连接参数` | `privateKey.includes('.ssh/test_key')`, but the value is built with `path.join` and reads `C:\Users\...\.ssh\test_key` | compare against `path.join('.ssh', 'test_key')`, and use `endsWith` instead of `includes` |
| `应该正确解析 allowed local paths` | entries `startsWith('/')`, but absolute paths begin with a drive letter | `path.isAbsolute` |
| `应允许配置的本地路径用于传输` | hardcoded `/tmp`; `path.resolve('/tmp/test.txt')` yields `D:\tmp\test.txt` on the current drive | use a real temp directory, matching what the neighbouring `本地允许路径应按连接隔离` test already does |
| `accepts initialize requests while pre-connect is still pending` | the stand-in TCP server never handled `error` on accepted sockets; killing the child resets the connection rather than closing it cleanly, and the unhandled event fails the test | `socket.on('error', () => {})` |

The last one is not really Windows-specific — a test double that accepts connections should tolerate a peer reset on any platform.

## Skips

Two tests assert behaviour Windows cannot produce. They are skipped rather than weakened, so they keep their full strength everywhere else.

- **`exits after SIGTERM even when stdin remains open`** — Windows has no POSIX signals. `child.kill('SIGTERM')` maps to `TerminateProcess`, so the handler under test never runs and the exit is always reported as signalled; the assertion cannot hold. Skipped on `win32` only. Shutdown on Windows is covered by `exits after stdin is closed`, which passes.
- **`本地路径校验应拒绝通过符号链接逃出允许目录`** — `fs.symlinkSync` needs administrator rights or developer mode. The skip is triggered by an actual `EPERM`/`EACCES` from the call rather than by a platform check, so the test still runs wherever symlinks are permitted — including an elevated Windows shell.

## Verification

Both `main` and this branch were run on a clean Linux install (`node:22-alpine`, fresh `npm ci`) to confirm no coverage is lost where it already worked: 132 tests, 132 passing, **0 skipped** in both cases. The skips only ever engage on Windows.

Test-only change; no product code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)