### PR TITLE
fix: shell transport hangs because ready probe matches echoed command

### DIFF
--- a/src/services/ssh-connection-manager.ts
+++ b/src/services/ssh-connection-manager.ts
@@ -1935,7 +1935,7 @@ export class SSHConnectionManager {
         readyMarker,
         this.getShellReadyTimeoutMs(config),
       );
-      this.configureShellSession(stream);
+      await this.configureShellSession(key, stream, config);
       this.shellReady.set(key, true);
       this.attachShellLifecycleListeners(key, stream);
     } catch (error) {
@@ -1960,7 +1960,20 @@ export class SSHConnectionManager {
       let settled = false;
       let timeoutId: NodeJS.Timeout;
       let probeIntervalId: NodeJS.Timeout;
-      const payload = `printf '${readyMarker}\\n'\n`;
+      // Escape the marker in the probe payload so the command text does not
+      // contain the literal marker string.  When the PTY echoes the probe
+      // command back (echo is still on during the first probe), the echo no
+      // longer matches readyMarker, so resolveIfReady only fires once the
+      // printf actually executes and emits the literal marker.  Without this,
+      // waitForShellReady resolves on the echoed command line, before the
+      // probed command has run — which is fatal when the probed command is
+      // `stty -echo` in configureShellSession: the next real command would be
+      // sent before echo is disabled and would itself be echoed, leaving
+      // extractShellCommandResult matching markers inside the echoed script.
+      const escapedMarker = readyMarker
+        .replace(/\\/g, "\\\\")
+        .replace(/_/g, "\\137");
+      const payload = `printf '${escapedMarker}\\n'\n`;
 
       const cleanup = () => {
         if (timeoutId) {
@@ -2061,9 +2074,30 @@ export class SSHConnectionManager {
     );
   }
 
-  private configureShellSession(stream: ClientChannel): void {
+  private async configureShellSession(
+    key: string,
+    stream: ClientChannel,
+    config: SSHConfig,
+  ): Promise<void> {
+    // Send `export PS1=''` and `stty -echo` first.  The verification probe
+    // (printf, emitted by waitForShellReady below with an escaped marker)
+    // follows them in the same shell input stream, so by the time the
+    // probe's literal marker is emitted, stty has executed and terminal echo
+    // is off.  We must NOT write our own `printf '${marker}'` here: that
+    // payload contains the literal marker, so when echo is still on it would
+    // be echoed back and waitForShellReady would resolve prematurely, before
+    // stty runs — leaving the next real command echoed.
     stream.write("export PS1=''\n");
     stream.write("stty -echo >/dev/null 2>&1 || true\n");
+
+    const verifyId = this.generateMarkerId("stty");
+    const verifyMarker = `__MCP_CONFIGURE__${verifyId}__`;
+    await this.waitForShellReady(
+      key,
+      stream,
+      verifyMarker,
+      this.getShellReadyTimeoutMs(config),
+    );
   }
 
   private runShellCommand(


### PR DESCRIPTION
## Problem
With `"transportMode": "shell"`, the first `executeCommand` after connect always times out. The connection succeeds and `shellReady` is set, but the command never returns.

## Root cause
`configureShellSession` sends `stty -echo` to stop the PTY from echoing command scripts back (an echoed `__MCP_END__…RC__%s__` confuses `extractShellCommandResult`, which tries to parse `%s` as the exit code). It relies on `waitForShellReady` to know when `stty` has run, but `waitForShellReady`'s probe payload is `printf '<marker>\n'` — the command text itself contains the literal marker. While echo is still on, the PTY echoes the probe line back, that echo contains the literal marker, and `resolveIfReady` matches it and resolves **on the echo, before `printf` runs**. So `stty` never gets the chance to take effect, and the first real command script is echoed too → `extractShellCommandResult` matches the echoed end marker, fails to parse `%s`, and the real output is never reached → timeout.

Verified by experiment that `stty -echo` itself is effective and persists (the next command is not echoed); the bug is purely that ssh-mcp-server could not reliably wait for `stty` to execute.

## Fix
Escape the marker in the probe payload (`_` → `\137`), so the probe command text no longer contains the literal marker. The PTY echo can no longer trigger a match, so `waitForShellReady` only resolves on the real `printf` output — by which point `stty` has executed. `configureShellSession` now `await`s that verification probe instead of fire-and-forgetting `stty`.

This is a source fix: the echoed text never contains the literal marker, so every literal-marker match (not just `resolveIfReady`) is immune, and `extractShellCommandResult` is left untouched — once `stty` is effective the command scripts are no longer echoed, so it only ever sees real output.

### Before / after
```
BEFORE:  probe printf 'MARKER'  → echo contains literal MARKER → resolve on echo (stty not yet run)
AFTER :  probe printf '\137…'   → echo has no literal MARKER   → resolve on real printf output (stty has run)
```

## Tested
OpenSSH 8.9p1 / Ubuntu 22.04 / bash 5.1. Before: first `executeCommand` times out. After: returns clean output, e.g. `hostname` → `bf8e232111ca`.
